### PR TITLE
Feat/fix clang errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ make all
 ctest -V
 ```
 
-
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTS=ON  CMAKE_C_FLAGS_RELWITHDEBUBINFO="-03 -g -DNDEBUG" ..
 * Special flags:
   + INSTALL:
     + empty (default) -> install rascal in the build folder

--- a/src/math/math_interface.cc
+++ b/src/math/math_interface.cc
@@ -28,6 +28,8 @@
 
 
 #include "math_interface.hh"
+#include "math/cephes/mconf.h"
+
 
 namespace rascal {
   namespace math {

--- a/src/math/math_interface.hh
+++ b/src/math/math_interface.hh
@@ -30,7 +30,6 @@
 #ifndef MATH_INTERFACE_H
 #define MATH_INTERFACE_H
 
-#include "math/cephes/mconf.h"
 
 namespace rascal {
   namespace math {

--- a/src/structure_managers/adaptor_neighbour_list.hh
+++ b/src/structure_managers/adaptor_neighbour_list.hh
@@ -2,7 +2,7 @@
  * file   adaptor_neighbour_list.hh
  *
  * @author Markus Stricker <markus.stricker@epfl.ch>
- * @outhor Till Junge <till.junge@epfl.ch>
+ * @author Till Junge <till.junge@epfl.ch>
  *
  * @date   04 Oct 2018
  *

--- a/src/structure_managers/adaptor_neighbour_list.hh
+++ b/src/structure_managers/adaptor_neighbour_list.hh
@@ -343,22 +343,7 @@ namespace rascal {
       return retval;
     }
 
-    /* ---------------------------------------------------------------------- */
-    //! get the dim-index array from a linear index
-    template <size_t Dim>
-    constexpr std::array<int, Dim>
-    get_ccoord(const std::array<int, Dim> & sizes,
-               const std::array<int, Dim> & origin, int index) {
-      std::array<int, Dim> retval{{0}};
-      int factor{1};
-      for (size_t i = Dim-1; i >=0; --i) {
-        retval[i] = index/factor%sizes[i] + origin[i];
-        if (i != 0 ) {
-          factor *= sizes[i];
-        }
-      }
-      return retval;
-    }
+
 
     /* ---------------------------------------------------------------------- */
     //! test if position inside

--- a/src/structure_managers/structure_manager_base.hh
+++ b/src/structure_managers/structure_manager_base.hh
@@ -40,6 +40,7 @@ namespace rascal{
   public:
     inline decltype(auto) get_property(std::string name);
     virtual size_t nb_clusters(size_t cluster_size) const = 0;
+    virtual ~StructureManagerBase() = default; 
   };
 
 

--- a/src/structure_managers/structure_manager_centers.hh
+++ b/src/structure_managers/structure_manager_centers.hh
@@ -175,10 +175,7 @@ namespace rascal {
      * structure.
      */
     inline Cell_ref get_cell() {
-      auto dim{traits::Dim};
-      return Cell_ref(this->atoms_object.cell.data(), dim,
-                      this->atoms_object.cell.size() / dim);
-      // return retval;
+      return Cell_ref(this->atoms_object.cell.data());
     }
 
     //! Returns the type of a given atom, given an AtomRef

--- a/src/structure_managers/structure_manager_lammps.hh
+++ b/src/structure_managers/structure_manager_lammps.hh
@@ -49,6 +49,8 @@ namespace rascal {
     constexpr static int Dim{3};
     constexpr static size_t MaxOrder{2};
     constexpr static AdaptorTraits::Strict Strict{AdaptorTraits::Strict::no};
+    constexpr static bool HasDistances{false};
+    constexpr static bool HasDirectionVectors{false};
     using LayerByOrder = std::index_sequence<0, 0>;
   };
 

--- a/tests/test_adaptor_neighbour_list.cc
+++ b/tests/test_adaptor_neighbour_list.cc
@@ -240,6 +240,7 @@ namespace rascal {
        * atom does not allow for comparison with other atom's number of
        * neighbours
        */
+      
       BOOST_CHECK_EQUAL(neighbours_per_atom1[0],
                         neighbours_per_atom2[0]);
       if (verbose) {

--- a/tests/test_adaptor_neighbour_list.cc
+++ b/tests/test_adaptor_neighbour_list.cc
@@ -2,13 +2,14 @@
  * file   test_adaptor_neighbour_list.cc
  *
  * @author Markus Stricker <markus.stricker@epfl.ch>
+ * @author Till Junge <till.junge@epfl.ch>
  *
  * @date   05 Oct 2018
  *
  * @brief tests the implementation of the adaptor for building a
  * neighbour list, depends on traits if it is full of minimal
  *
- * Copyright © 2018 Markus Stricker, COSMO (EPFL), LAMMM (EPFL)
+ * Copyright © 2018 Markus Stricker, Till Junge, COSMO (EPFL), LAMMM (EPFL)
  *
  * librascal is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -206,14 +207,17 @@ namespace rascal {
       for (auto atom : pair_manager1) {
         neighbours_per_atom1.push_back(0);
         for (auto pair : atom) {
-          if (verbose) {
-            std::cout << "1 pair "
-                      << atom.back() << " "
-                      << pair.back() << std::endl;
-          }
           double dist = {(atom.get_position()
                           - pair.get_position()).norm()};
-          if (dist < cutoff_tmp) {
+          bool is_in{dist < cutoff_tmp};
+          if (verbose) {
+            std::cout << "1 pair ("
+                      << atom.get_position().transpose() << ", "
+                      << pair.get_position().transpose() << ", "
+                      << dist << ", " << cutoff_tmp << ", " << is_in
+                      << ")" <<std::endl;
+          }
+          if (is_in) {
             neighbours_per_atom1.back()++;
           }
         }
@@ -222,14 +226,17 @@ namespace rascal {
       for (auto atom : pair_manager2) {
         neighbours_per_atom2.push_back(0);
         for (auto pair : atom) {
-          if (verbose) {
-            std::cout << "2 pair "
-                      << atom.back() << " "
-                      << pair.back() << std::endl;
-          }
           double dist = {(atom.get_position()
                           - pair.get_position()).norm()};
-          if (dist < cutoff_tmp) {
+          bool is_in{dist < cutoff_tmp};
+          if (verbose) {
+            std::cout << "2 pair ("
+                      << atom.get_position().transpose() << ", "
+                      << pair.get_position().transpose() << ", "
+                      << dist << ", " << cutoff_tmp << ", " << is_in
+                      << ")" <<std::endl;
+          }
+          if (is_in) {
             neighbours_per_atom2.back()++;
           }
         }
@@ -240,7 +247,7 @@ namespace rascal {
        * atom does not allow for comparison with other atom's number of
        * neighbours
        */
-      
+
       BOOST_CHECK_EQUAL(neighbours_per_atom1[0],
                         neighbours_per_atom2[0]);
       if (verbose) {


### PR DESCRIPTION
The error came from using a `auto` value (as opposed to rvalue, which would be safe if moved from, but out of the question here, because we use value twice) to store the result of a `Eigen::solve()`:
`auto multiplicator = cell.ldlt().solve(xpos)`**.eval()**`;`

 Eigen's expression templates need to be either evaluated or cast into a type of which we **know** they own their memory, else they cannot be safely stored. 