### PR TITLE
quick fix for using import rascal in build folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,3 +147,9 @@ if(CPPLINT_FOUND)
   "--filter=-build/namespaces")
 endif()
 
+# make python library of rascal usable in build folder
+add_custom_target(pyrascalcopy ALL)
+add_custom_command(TARGET pyrascalcopy POST_BUILD
+  COMMAND cp -R
+  ${CMAKE_SOURCE_DIR}/rascal ${CMAKE_BINARY_DIR}
+  )

--- a/rascal/lib/__init__.py
+++ b/rascal/lib/__init__.py
@@ -1,3 +1,15 @@
-from ._rascal import (StructureManager,FeatureManager,Adaptor,
-                      RepresentationManager,utils,math)
-from ._rascal.utils import sparsification
+import sys
+import os
+
+sys.path.append(os.path.join(
+    os.path.dirname(__file__), "../../bindings/"))
+
+"""This is not an elegant solution and not pep8 conform (comment of Till)
+bindings/ and /rascal/ should be the same.
+"""
+
+import _rascal
+from _rascal import (StructureManager, FeatureManager, Adaptor,
+                     RepresentationManager, utils, math)
+
+from _rascal.utils import sparsification


### PR DESCRIPTION
As is says in the header...quick and dirty.

The other stuff will be done next year including rearranging bindings and stuff.

`import rascal` now works in the current build-folder

