### PR TITLE
added empty line removal to clang-format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,6 @@ jobs:
                         - run:
                                 command: |
                                         cd build
-                                        make lint
-                        - run:
-                                command: |
-                                        cd build
                                         make
                         - run:
                                 command: |
@@ -49,6 +45,10 @@ jobs:
                                 command: |
                                         cd build
                                         make dev_doc
+                        - run:
+                                command: |
+                                        cd build
+                                        make lint
 
         build_ubuntu_g++-6.4:
                 docker:
@@ -86,10 +86,6 @@ jobs:
                         - run:
                                 command: |
                                         cd build
-                                        make lint
-                        - run:
-                                command: |
-                                        cd build
                                         make
                         - run:
                                 command: |
@@ -99,6 +95,10 @@ jobs:
                                 command: |
                                         cd build
                                         make dev_doc
+                        - run:
+                                command: |
+                                        cd build
+                                        make lint
         build_ubuntu_g++-7.3:
                 docker:
                         - image: ubuntu:18.04
@@ -134,10 +134,6 @@ jobs:
                         - run:
                                 command: |
                                         cd build
-                                        make lint
-                        - run:
-                                command: |
-                                        cd build
                                         make
                         - run:
                                 command: |
@@ -147,6 +143,10 @@ jobs:
                                 command: |
                                         cd build
                                         make dev_doc
+                        - run:
+                                command: |
+                                        cd build
+                                        make lint
 
         build_ubuntu_g++-7.3_debug:
                 docker:
@@ -183,10 +183,6 @@ jobs:
                         - run:
                                 command: |
                                         cd build
-                                        make lint
-                        - run:
-                                command: |
-                                        cd build
                                         make
                         - run:
                                 command: |
@@ -196,6 +192,10 @@ jobs:
                                 command: |
                                         cd build
                                         make dev_doc
+                        - run:
+                                command: |
+                                        cd build
+                                        make lint
 
         build_ubuntu_clang-7.0:
                 docker:
@@ -245,10 +245,6 @@ jobs:
                         - run:
                                 command: |
                                         cd build
-                                        make lint
-                        - run:
-                                command: |
-                                        cd build
                                         make
                         - run:
                                 command: |
@@ -258,6 +254,10 @@ jobs:
                                 command: |
                                         cd build
                                         make dev_doc
+                        - run:
+                                command: |
+                                        cd build
+                                        make lint
 
         build_ubuntu_clang-7.0_debug:
                 docker:
@@ -307,10 +307,6 @@ jobs:
                         - run:
                                 command: |
                                         cd build
-                                        make lint
-                        - run:
-                                command: |
-                                        cd build
                                         make
                         - run:
                                 command: |
@@ -320,6 +316,10 @@ jobs:
                                 command: |
                                         cd build
                                         make dev_doc
+                        - run:
+                                command: |
+                                        cd build
+                                        make lint
 
         build_ubuntu_clang-6.0:
                 docker:
@@ -358,10 +358,6 @@ jobs:
                         - run:
                                 command: |
                                         cd build
-                                        make lint
-                        - run:
-                                command: |
-                                        cd build
                                         make
                         - run:
                                 command: |
@@ -371,6 +367,10 @@ jobs:
                                 command: |
                                         cd build
                                         make dev_doc
+                        - run:
+                                command: |
+                                        cd build
+                                        make lint
 
 
         build_ubuntu_clang-5.0:
@@ -410,10 +410,6 @@ jobs:
                         - run:
                                 command: |
                                         cd build
-                                        make lint
-                        - run:
-                                command: |
-                                        cd build
                                         make
                         - run:
                                 command: |
@@ -423,6 +419,10 @@ jobs:
                                 command: |
                                         cd build
                                         make dev_doc
+                        - run:
+                                command: |
+                                        cd build
+                                        make lint
         build_ubuntu_clang-4.0:
                 docker:
                         - image: ubuntu:18.04
@@ -464,10 +464,6 @@ jobs:
                         - run:
                                 command: |
                                         cd build
-                                        make lint
-                        - run:
-                                command: |
-                                        cd build
                                         make
                         - run:
                                 command: |
@@ -477,6 +473,10 @@ jobs:
                                 command: |
                                         cd build
                                         make dev_doc
+                        - run:
+                                command: |
+                                        cd build
+                                        make lint
 
 workflows:
         version: 2

--- a/.clang-format
+++ b/.clang-format
@@ -5,3 +5,4 @@ SortIncludes: false
 PointerAlignment: Middle
 AlwaysBreakTemplateDeclarations: true
 ColumnLimit: 80
+KeepEmptyLinesAtTheStartOfBlocks: false

--- a/src/structure_managers/property_block_sparse.hh
+++ b/src/structure_managers/property_block_sparse.hh
@@ -492,8 +492,7 @@ namespace rascal {
     }
 
     template <size_t CallerOrder, size_t CallerLayer, size_t Order_ = Order,
-        std::enable_if_t<(Order_ == 1) and (CallerOrder > 1), int> = // NOLINT
-                  0>  // NOLINT
+              std::enable_if_t<(Order_ == 1) && (CallerOrder > 1), int> = 0>
     inline decltype(auto)
     operator[](const ClusterRefKey<CallerOrder, CallerLayer> & id) {
       return this->operator[](this->get_manager().get_atom_index(


### PR DESCRIPTION
This is a small one, solving issue #99 

I had to clear my head - dug a little in the clang-format documentation and added the corresponding line into the `.clang-format` file.
I also reformatted the template parameters, because it looked ugly, the linter is happy with `&&` instead of `and`.

Empty lines at the beginning of functions are now removed automatically with `make pretty-cpp`.
I think with this we do not need to take out the linter from the CI.
If other things pop up, we will try to automate them also.