### PR TITLE
Do not use constant references when passing/returning primitive types

### DIFF
--- a/bindings/bind_py_structure_manager.cc
+++ b/bindings/bind_py_structure_manager.cc
@@ -309,7 +309,7 @@ namespace rascal {
                                            py::module & m_adaptor) {
       m_adaptor.def(
           name.c_str(),
-          [](ImplementationPtr_t & manager, const double & cutoff) {
+          [](ImplementationPtr_t & manager, double cutoff) {
             return make_adapted_manager<AdaptorStrict, Implementation_t>(
                 manager, cutoff);
           },
@@ -420,8 +420,8 @@ namespace rascal {
                                            py::module & m_adaptor) {
       m_adaptor.def(
           name.c_str(),
-          [](ImplementationPtr_t manager, const double & cutoff,
-             const bool & consider_ghost_neighbours) {
+          [](ImplementationPtr_t manager, double cutoff,
+             bool consider_ghost_neighbours) {
             return make_adapted_manager<AdaptorNeighbourList, Implementation_t>(
                 manager, cutoff, consider_ghost_neighbours);
           },
@@ -507,7 +507,7 @@ namespace rascal {
      */
     manager_collection.def(
         "add_structures",
-        (void (ManagerCollection_t::*)(const std::string &, const int &, int)) &
+        (void (ManagerCollection_t::*)(const std::string &, int, int)) &
             ManagerCollection_t::add_structures,
         R"(Read a file and extract the structures from start to start + length.)",
         py::arg("filename"), py::arg("start") = 0, py::arg("length") = -1);

--- a/src/atomic_structure.hh
+++ b/src/atomic_structure.hh
@@ -243,20 +243,20 @@ namespace rascal {
      * @param threshold2 tolerance parameter squared for the similarity
      *                    comparison
      */
-    inline bool is_similar(const double &) const { return true; }
+    inline bool is_similar(double) const { return true; }
 
-    inline bool is_similar(const json_io::AtomicJsonData &, const double &) {
+    inline bool is_similar(const json_io::AtomicJsonData &, double) {
       return false;
     }
 
-    inline bool is_similar(const json &, const double &) const { return false; }
+    inline bool is_similar(const json &, double) const { return false; }
 
-    inline bool is_similar(const std::string &, const double &) const {
+    inline bool is_similar(const std::string &, double) const {
       return false;
     }
 
     inline bool is_similar(const AtomicStructure<Dim> & other,
-                           const double & threshold2) const {
+                           double threshold2) const {
       bool is_similar_{true};
       if (this->positions.cols() == other.positions.cols()) {
         if ((this->pbc.array() != other.pbc.array()).any() or
@@ -278,7 +278,7 @@ namespace rascal {
     inline bool is_similar(const PositionsInput_t & positions,
                            const AtomTypesInput_t & atom_types,
                            const CellInput_t cell, const PBCInput_t & pbc,
-                           const double & threshold2) const {
+                           double threshold2) const {
       auto center_atoms_mask = ArrayB_t::Ones(atom_types.size());
       return this->is_similar(positions, atom_types, cell, pbc,
                               center_atoms_mask, threshold2);
@@ -288,7 +288,7 @@ namespace rascal {
                            const AtomTypesInput_t & atom_types,
                            const CellInput_t cell, const PBCInput_t & pbc,
                            const ArrayB_ref & center_atoms_mask,
-                           const double & threshold2) const {
+                           double threshold2) const {
       bool is_similar_{true};
       if (this->positions.cols() == positions.cols()) {
         if ((this->pbc.array() != pbc.array()).any() or

--- a/src/json_io.hh
+++ b/src/json_io.hh
@@ -52,14 +52,14 @@ namespace Eigen {
     struct ResizeEigen {
       template <typename _Scalar, int _Options, int _MaxRows, int _MaxCols>
       static void apply_mat(
-          const size_t & /* n_rows*/, const size_t & /*n_cols */,
+          size_t /* n_rows*/, size_t /*n_cols */,
           Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols> & /*s*/) {
         // assert(n_rows == _Rows);
         // assert(n_cols == _Cols);
       }
       template <typename _Scalar, int _Options, int _MaxRows, int _MaxCols>
       static void apply_arr(
-          const size_t & /* n_rows*/, const size_t & /*n_cols */,
+          size_t /* n_rows*/, size_t /*n_cols */,
           Array<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols> & /*s*/) {
         // assert(n_rows == _Rows);
         // assert(n_cols == _Cols);
@@ -70,14 +70,14 @@ namespace Eigen {
     struct ResizeEigen<Dynamic, Dynamic> {
       template <typename _Scalar, int _Options, int _MaxRows, int _MaxCols>
       static void apply_mat(
-          const size_t & n_rows, const size_t & n_cols,
+          size_t n_rows, size_t n_cols,
           Matrix<_Scalar, Dynamic, Dynamic, _Options, _MaxRows, _MaxCols> & s) {
         s.resize(n_rows, n_cols);
       }
 
       template <typename _Scalar, int _Options, int _MaxRows, int _MaxCols>
       static void apply_arr(
-          const size_t & n_rows, const size_t & n_cols,
+          size_t n_rows, size_t n_cols,
           Array<_Scalar, Dynamic, Dynamic, _Options, _MaxRows, _MaxCols> & s) {
         s.resize(n_rows, n_cols);
       }
@@ -87,7 +87,7 @@ namespace Eigen {
     struct ResizeEigen<Dynamic, _Cols> {
       template <typename _Scalar, int _Options, int _MaxRows, int _MaxCols>
       static void apply_mat(
-          const size_t & n_rows, const size_t & /* n_cols */,
+          size_t n_rows, size_t /* n_cols */,
           Matrix<_Scalar, Dynamic, _Cols, _Options, _MaxRows, _MaxCols> & s) {
         // assert(n_cols == _Cols);
         s.resize(n_rows, _Cols);
@@ -95,7 +95,7 @@ namespace Eigen {
 
       template <typename _Scalar, int _Options, int _MaxRows, int _MaxCols>
       static void apply_arr(
-          const size_t & n_rows, const size_t & /*n_cols */,
+          size_t n_rows, size_t /*n_cols */,
           Array<_Scalar, Dynamic, _Cols, _Options, _MaxRows, _MaxCols> & s) {
         // assert(n_cols == _Cols);
         s.resize(n_rows, _Cols);
@@ -106,7 +106,7 @@ namespace Eigen {
     struct ResizeEigen<_Rows, Dynamic> {
       template <typename _Scalar, int _Options, int _MaxRows, int _MaxCols>
       static void apply_mat(
-          const size_t & /*n_rows */, const size_t & n_cols,
+          size_t /*n_rows */, size_t n_cols,
           Matrix<_Scalar, _Rows, Dynamic, _Options, _MaxRows, _MaxCols> & s) {
         // assert(n_rows == _Rows);
         s.resize(_Rows, n_cols);
@@ -114,7 +114,7 @@ namespace Eigen {
 
       template <typename _Scalar, int _Options, int _MaxRows, int _MaxCols>
       static void apply_arr(
-          const size_t & /*n_rows */, const size_t & n_cols,
+          size_t /*n_rows */, size_t n_cols,
           Array<_Scalar, _Rows, Dynamic, _Options, _MaxRows, _MaxCols> & s) {
         // assert(n_rows == _Rows);
         s.resize(_Rows, n_cols);

--- a/src/math/bessel.hh
+++ b/src/math/bessel.hh
@@ -69,7 +69,7 @@ namespace rascal {
        * @param x_v      Eigen::Array of x-values (part of the argument of the
        *                 first exponential; see equation above)
        */
-      void precompute(const size_t & l_max,
+      void precompute(size_t l_max,
                       const Eigen::Ref<const Eigen::VectorXd> & x_v) {
         this->x_v = x_v.array();
         this->n_max = x_v.size();
@@ -102,8 +102,8 @@ namespace rascal {
        * @param n_rows number of rows where the recursion is applicable
        *               from the bottom
        */
-      void upward_recursion(const double & distance, const double & fac_a,
-                            const int & n_rows) {
+      void upward_recursion(double distance, double fac_a,
+                            int n_rows) {
         auto vals = this->bessel_values.bottomRows(n_rows);
         // i_0(z) = sinh(z) / z
         vals.col(0) =
@@ -146,8 +146,8 @@ namespace rascal {
        * @param n_rows number of rows where the recursion is applicable
        *               from the top
        */
-      void downward_recursion(const double & distance, const double & fac_a,
-                              const int & n_rows) {
+      void downward_recursion(double distance, double fac_a,
+                              int n_rows) {
         auto vals = this->bessel_values.topRows(n_rows);
         this->exp_bessel_arg = Eigen::exp(-this->bessel_arg.head(n_rows));
         this->efac = std::exp(-fac_a * distance * distance) *
@@ -178,7 +178,7 @@ namespace rascal {
        * threshold the MBSFs are set to 0 because of the numerical noise
        * arrising below 1e-150.
        */
-      inline void calc(const double & distance, const double & fac_a) {
+      inline void calc(double distance, double fac_a) {
         this->bessel_arg = (2. * fac_a * distance) * this->x_v;
         this->bessel_arg_i = this->bessel_arg.inverse();
         // find the index where bessel_arg is larger than 50

--- a/src/math/gauss_legendre.hh
+++ b/src/math/gauss_legendre.hh
@@ -49,7 +49,7 @@ namespace rascal {
      * for potential improvements of the method used here (Numerical Recepies)
      */
     inline MatrixX2_t compute_gauss_legendre_points_weights(
-        const double & r_st, const double & r_nd, const int & order_n) {
+        double r_st, double r_nd, int order_n) {
       if (order_n < 2) {
         throw std::runtime_error(R"(there should be at least 2 integration
         points but: order_n < 2 == true)");

--- a/src/math/hyp1f1.hh
+++ b/src/math/hyp1f1.hh
@@ -48,32 +48,32 @@ namespace rascal {
      *
      * G refers to the modified 1F1 defined below
      */
-    inline double recurence_to_val_downward(const double & a, const double & b,
-                                            const double & z,
-                                            const double & M1p2p,
-                                            const double & M1p1p) {
+    inline double recurence_to_val_downward(double a, double b,
+                                            double z,
+                                            double M1p2p,
+                                            double M1p1p) {
       return z * (a - b) * M1p2p / (b * (b + 1)) + M1p1p;
     }
 
-    inline double recurence_to_der_downward(const double & a, const double & b,
-                                            const double & z,
-                                            const double & M2p3p,
-                                            const double & M1p2p) {
+    inline double recurence_to_der_downward(double a, double b,
+                                            double z,
+                                            double M2p3p,
+                                            double M1p2p) {
       return z * (a + 1) * M2p3p / ((b + 2) * (b + 1)) + M1p2p;
     }
 
-    inline double recurence_G_to_val_downward(const double & a,
-                                              const double & b,
-                                              const double & z,
-                                              const double & M1p2p,
-                                              const double & M1p1p) {
+    inline double recurence_G_to_val_downward(double a,
+                                              double b,
+                                              double z,
+                                              double M1p2p,
+                                              double M1p1p) {
       return (z * (a - b) * M1p2p + M1p1p * b) / a;
     }
 
-    inline double recurence_G_to_der_downward(const double &, const double & b,
-                                              const double & z,
-                                              const double & M2p3p,
-                                              const double & M1p2p) {
+    inline double recurence_G_to_der_downward(double, double b,
+                                              double z,
+                                              double M2p3p,
+                                              double M1p2p) {
       return z * M2p3p + M1p2p * (b + 1);
     }
 
@@ -102,8 +102,8 @@ namespace rascal {
      public:
       size_t n_terms{0};
 
-      Hyp1f1Series(const double & a, const double & b, const size_t & mmax,
-                   const double & tolerance = 1e-14)
+      Hyp1f1Series(double a, double b, size_t mmax,
+                   double tolerance = 1e-14)
           : a{a}, b{b}, mmax{mmax}, prefac{std::tgamma(a) / std::tgamma(b)},
             tolerance{tolerance} {
         // when a == b, 1F1 is an exponential
@@ -135,9 +135,9 @@ namespace rascal {
        * We do this to avoid computing both d1F1/dz and 1F1 when asking for
        * gradients and perform this step in Hyp1f1SphericalExpansion.
        */
-      inline double calc(const double & z, const double & z2,
-                         const double & ez2, const bool & derivative = false,
-                         const int & n_terms = -1) {
+      inline double calc(double z, double z2,
+                         double ez2, bool derivative = false,
+                         int n_terms = -1) {
         using math::pow;
         double result{0.};
         if (not this->is_exp) {
@@ -148,8 +148,8 @@ namespace rascal {
         return result;
       }
 
-      inline double calc(const double & z, const bool & derivative = false,
-                         const int & n_terms = -1) {
+      inline double calc(double z, bool derivative = false,
+                         int n_terms = -1) {
         double result{0.};
         if (not this->is_exp) {
           result = this->hyp1f1(z, derivative, n_terms);
@@ -159,8 +159,8 @@ namespace rascal {
         return result;
       }
       //! Computes 1F1
-      inline double hyp1f1(const double & z, const bool & derivative,
-                           const int & n_terms) {
+      inline double hyp1f1(double z, bool derivative,
+                           int n_terms) {
         using math::pow;
         size_t mmax{0};
         if (n_terms == -1) {
@@ -184,8 +184,8 @@ namespace rascal {
         return res;
       }
 
-      inline double sum(const double & z, const Eigen::VectorXd & coefficient,
-                        const size_t & mmax, const int & n_terms) {
+      inline double sum(double z, const Eigen::VectorXd & coefficient,
+                        size_t mmax, int n_terms) {
         // perform the sum
         double res{1.0}, a1{1.0}, zpow{z}, z4{z * z};
         z4 *= z4;
@@ -246,7 +246,7 @@ namespace rascal {
       Eigen::VectorXd coeff{};
       Eigen::VectorXd coeff_derivative{};
 
-      inline double z_power_a_b(const double & z) {
+      inline double z_power_a_b(double z) {
         using math::pow;
         double fac{0.};
         if (this->is_n_and_l) {
@@ -260,8 +260,8 @@ namespace rascal {
      public:
       size_t n_terms{0};
 
-      Hyp1f1Asymptotic(const double & a, const double & b, const size_t & mmax,
-                       const double & tolerance = 1e-14)
+      Hyp1f1Asymptotic(double a, double b, size_t mmax,
+                       double tolerance = 1e-14)
           : a{a}, b{b}, prefac{std::tgamma(b) / std::tgamma(a)},
             tolerance{tolerance}, mmax{mmax} {
         double intpart;
@@ -299,9 +299,9 @@ namespace rascal {
        * We do this to avoid computing both d1F1/dz and 1F1 when asking for
        * gradients and perform this step in Hyp1f1SphericalExpansion.
        */
-      inline double calc(const double & z, const double & z2,
-                         const bool & derivative = false,
-                         const int & n_terms = -1) {
+      inline double calc(double z, double z2,
+                         bool derivative = false,
+                         int n_terms = -1) {
         using math::pow;
         double result{0.};
         if (not this->is_exp) {
@@ -315,8 +315,8 @@ namespace rascal {
       }
 
       //! Computes 1F1
-      inline double calc(const double & z, const bool & derivative = false,
-                         const int & n_terms = -1) {
+      inline double calc(double z, bool derivative = false,
+                         int n_terms = -1) {
         using math::pow;
         if (not this->is_exp) {
           auto fac{this->z_power_a_b(z)};
@@ -332,8 +332,8 @@ namespace rascal {
       }
 
       //! computes hyp2f0 with arg1 = b-a and arg2 = 1-a arg3 = 1 / z
-      inline double hyp2f0(const double & z, const bool & derivative,
-                           const int & n_terms) {
+      inline double hyp2f0(double z, bool derivative,
+                           int n_terms) {
         using math::pow;
         this->n_terms = this->mmax;
 
@@ -358,8 +358,8 @@ namespace rascal {
         return res;
       }
 
-      inline double sum(const double & z, const Eigen::VectorXd & coefficient,
-                        const size_t & mmax, const int & n_terms) {
+      inline double sum(double z, const Eigen::VectorXd & coefficient,
+                        size_t mmax, int n_terms) {
         double iz{1.0 / z};
         double res{1.}, izpow{1.}, s_i{1.};
         // perform the sum
@@ -469,8 +469,8 @@ namespace rascal {
       }
 
      public:
-      Hyp1f1(const double & a, const double & b, const size_t & mmax = 500,
-             const double & tolerance = 1e-13)
+      Hyp1f1(double a, double b, size_t mmax = 500,
+             double tolerance = 1e-13)
           : hyp1f1_series{a, b, mmax, tolerance}, hyp1f1_asymptotic{a, b, mmax,
                                                                     tolerance},
             a{a}, b{b}, tolerance{tolerance} {
@@ -489,7 +489,7 @@ namespace rascal {
       double get_z_switch() { return this->z_asympt; }
 
       //! Compute @f${}_1F_1(a,b,z)@f$
-      inline double calc(const double & z, const bool & derivative = false) {
+      inline double calc(double z, bool derivative = false) {
         if (z > this->z_asympt) {
           return this->hyp1f1_asymptotic.calc(z, derivative);
         } else {
@@ -497,8 +497,8 @@ namespace rascal {
         }
       }
 
-      inline double calc_numerical_derivative(const double & z,
-                                              const double & h) {
+      inline double calc_numerical_derivative(double z,
+                                              double h) {
         if (z > this->z_asympt) {
           double fzp{this->hyp1f1_asymptotic.calc(z + h)};
           size_t n_terms{this->hyp1f1_asymptotic.n_terms};
@@ -525,8 +525,8 @@ namespace rascal {
        * when asking for gradients and perform this step in
        * Hyp1f1SphericalExpansion.
        */
-      inline double calc(const double & z, const double & z2,
-                         const double & ez2, const bool & derivative = false) {
+      inline double calc(double z, double z2,
+                         double ez2, bool derivative = false) {
         if (z > this->z_asympt) {
           return this->hyp1f1_asymptotic.calc(z, z2, derivative);
         } else {
@@ -569,25 +569,25 @@ namespace rascal {
       Eigen::ArrayXd z{};
       Eigen::ArrayXd dz_dr{};
 
-      inline int get_pos(const int & n_radial, const int & l_angular) {
+      inline int get_pos(int n_radial, int l_angular) {
         return l_angular + (this->max_angular + 1) * n_radial;
       }
 
-      inline double get_a(const int & n_radial, const int & l_angular) {
+      inline double get_a(int n_radial, int l_angular) {
         return 0.5 * (n_radial + l_angular + 3);
       }
 
-      inline double get_b(const int & l_angular) { return l_angular + 1.5; }
+      inline double get_b(int l_angular) { return l_angular + 1.5; }
 
      public:
-      Hyp1f1SphericalExpansion(const bool & recursion = false,
-                               const double & tolerance = 1e-14,
-                               const size_t & precomputation_size = 200)
+      Hyp1f1SphericalExpansion(bool recursion = false,
+                               double tolerance = 1e-14,
+                               size_t precomputation_size = 200)
           : tolerance{tolerance},
             precomputation_size{precomputation_size}, recursion{recursion} {}
 
       //! initialize the 1F1 computers
-      void precompute(const size_t & max_radial, const size_t & max_angular) {
+      void precompute(size_t max_radial, size_t max_angular) {
         this->max_angular = max_angular;
         this->max_radial = max_radial;
         this->values.resize(max_radial, max_angular + 1);
@@ -605,16 +605,16 @@ namespace rascal {
       }
 
       //! helper function to compute z for one set of n, l, z
-      inline double calc(const size_t & n_radial, const size_t & l_angular,
-                         const double & z) {
+      inline double calc(size_t n_radial, size_t l_angular,
+                         double z) {
         int ipos{this->get_pos(n_radial, l_angular)};
         return this->hyp1f1[ipos].calc(z);
       }
 
       //! helper function to compute z for one set of n, l, custom z
-      inline double calc(const size_t & n_radial, const size_t & l_angular,
-                         const double & r_ij, const double & alpha,
-                         const double & beta) {
+      inline double calc(size_t n_radial, size_t l_angular,
+                         double r_ij, double alpha,
+                         double beta) {
         int ipos{this->get_pos(n_radial, l_angular)};
         double z{math::pow(alpha * r_ij, 2) / (alpha + beta)};
         double z2{-alpha * r_ij * r_ij};
@@ -623,9 +623,9 @@ namespace rascal {
       }
 
       //! the work horse that computes G for all possible n, l values
-      inline void calc(const double & r_ij, const double & alpha,
+      inline void calc(double r_ij, double alpha,
                        const Vector_Ref & fac_b,
-                       const bool & derivative = false) {
+                       bool derivative = false) {
         if (not this->recursion or this->max_angular < 3) {
           // recursion needs 4 evaluations of 1F1 so not worth it if l_max < 3
           this->calc_direct(r_ij, alpha, fac_b, derivative);
@@ -638,7 +638,7 @@ namespace rascal {
        *  Computes G and dG/dz*dz/dr using recursion relations with
        *  z = (alpha * r_ij)**2 / (alpha + fac_b)
        */
-      inline void calc_recursion(const double & r_ij, const double & alpha,
+      inline void calc_recursion(double r_ij, double alpha,
                                  const Vector_Ref & fac_b) {
         double M1p2p{0.}, M2p3p{0.}, MP1p2p{0.}, MP2p3p{0.}, M1p1p{0.}, Moo{0.},
             MP1p1p{0.}, MPoo{0.};
@@ -703,9 +703,9 @@ namespace rascal {
       }
 
       //! computes G by direct evaluation
-      inline void calc_direct(const double & r_ij, const double & alpha,
+      inline void calc_direct(double r_ij, double alpha,
                               const Vector_Ref & fac_b,
-                              const bool & derivative) {
+                              bool derivative) {
         // computes some intermediates that accelerate calculations further
         // down
         double alpha_rij{alpha * r_ij};

--- a/src/math/math_utils.hh
+++ b/src/math/math_utils.hh
@@ -98,7 +98,7 @@ namespace rascal {
 
       //! integer power
       template <typename Scalar_>
-      inline double pow_i(const Scalar_ & x, const int & n) {
+      inline double pow_i(const Scalar_ & x, int n) {
         size_t un{0};
         double value{static_cast<double>(x)};
 
@@ -114,37 +114,37 @@ namespace rascal {
     }  // namespace details
 
     //! integer power
-    inline double pow(const double & x, const int & n) {
+    inline double pow(double x, int n) {
       return details::pow_i(x, n);
     }
 
     //! integer power
-    inline double pow(const int & x, const int & n) {
+    inline double pow(int x, int n) {
       return details::pow_i(x, n);
     }
 
     //! integer power
-    inline double pow(const size_t & x, const int & n) {
+    inline double pow(size_t x, int n) {
       return details::pow_i(x, n);
     }
 
     //! unsingned integer power
-    inline double pow(const double & x, const std::size_t & n) {
+    inline double pow(double x, size_t n) {
       return details::pow_u(x, n);
     }
 
     //! unsingned integer power
-    inline int pow(const int & x, const std::size_t & n) {
+    inline int pow(int x, size_t n) {
       return details::pow_u(x, n);
     }
 
     //! unsingned integer power
-    inline size_t pow(const size_t & x, const std::size_t & n) {
+    inline size_t pow(size_t x, size_t n) {
       return details::pow_u(x, n);
     }
 
     //! general power
-    inline double pow(const double & x, const double & n) {
+    inline double pow(double x, double n) {
       return std::pow(x, n);
     }
 
@@ -165,7 +165,7 @@ namespace rascal {
     struct MakePositiveIntegerPower {
       typedef Scalar result_type;
       size_t b;
-      explicit MakePositiveIntegerPower(const size_t & b) : b{b} {}
+      explicit MakePositiveIntegerPower(size_t b) : b{b} {}
 
       Scalar operator()(const Scalar & a) const { return pow(a, this->b); }
     };
@@ -195,9 +195,9 @@ namespace rascal {
      * function.
      *
      */
-    inline double switching_function_cosine(const double & r,
-                                            const double & cutoff,
-                                            const double & smooth_width) {
+    inline double switching_function_cosine(double r,
+                                            double cutoff,
+                                            double smooth_width) {
       if (r <= (cutoff - smooth_width)) {
         return 1.0;
       } else if (r > cutoff) {
@@ -225,8 +225,8 @@ namespace rascal {
      *                                              / smooth_width)
      */
     inline double
-    derivative_switching_funtion_cosine(const double & r, const double & cutoff,
-                                        const double & smooth_width) {
+    derivative_switching_funtion_cosine(double r, double cutoff,
+                                        double smooth_width) {
       if (r <= (cutoff - smooth_width)) {
         return 0.0;
       } else if (r > cutoff) {

--- a/src/math/spherical_harmonics.hh
+++ b/src/math/spherical_harmonics.hh
@@ -363,8 +363,8 @@ namespace rascal {
        * \f$\sin(m\phi)\f$ in the second column, with \f$m\f$ being the row
        * index
        */
-      void compute_cos_sin_angle_multiples(const double & cos_phi,
-                                           const double & sin_phi) {
+      void compute_cos_sin_angle_multiples(double cos_phi,
+                                           double sin_phi) {
         for (size_t m_count{0}; m_count < this->max_angular + 1; m_count++) {
           if (m_count == 0) {
             this->cos_sin_m_phi.row(m_count) << 1.0, 0.0;

--- a/src/representations/calculator_sorted_coulomb.hh
+++ b/src/representations/calculator_sorted_coulomb.hh
@@ -217,7 +217,7 @@ namespace rascal {
     //! set hypers
     inline void set_hyperparameters(const Hypers_t & /*hypers*/);
 
-    inline void update_central_cutoff(const double & /*cutoff*/);
+    inline void update_central_cutoff(double /*cutoff*/);
 
     /**
      * check if size of the calculator is enough for current structure
@@ -302,9 +302,9 @@ namespace rascal {
     }
 
     //! scale cutoff factor depending on distance and decay
-    inline double get_cutoff_factor(const double & distance,
-                                    const double & cutoff,
-                                    const double & decay) {
+    inline double get_cutoff_factor(double distance,
+                                    double cutoff,
+                                    double decay) {
       if (distance <= cutoff - decay) {
         return 1.;
       } else if (distance > cutoff) {
@@ -359,7 +359,7 @@ namespace rascal {
   }
 
   inline void
-  CalculatorSortedCoulomb::update_central_cutoff(const double & cutoff) {
+  CalculatorSortedCoulomb::update_central_cutoff(double cutoff) {
     this->central_cutoff = cutoff;
 
     if ((this->hypers["interaction_cutoff"] < 0) or

--- a/src/representations/calculator_spherical_expansion.hh
+++ b/src/representations/calculator_spherical_expansion.hh
@@ -358,7 +358,7 @@ namespace rascal {
       //! define the contribution from a neighbour atom to the expansion
       template <AtomicSmearingType AST, size_t Order, size_t Layer>
       Matrix_Ref
-      compute_neighbour_contribution(const double & distance,
+      compute_neighbour_contribution(double distance,
                                      ClusterRefKey<Order, Layer> & pair) {
         using math::PI;
         using math::pow;
@@ -434,7 +434,7 @@ namespace rascal {
        */
       template <AtomicSmearingType AST, size_t Order, size_t Layer>
       Matrix_Ref
-      compute_neighbour_derivative(const double & distance,
+      compute_neighbour_derivative(double distance,
                                    ClusterRefKey<Order, Layer> & /*pair*/) {
         using math::PI;
         using math::pow;
@@ -701,7 +701,7 @@ namespace rascal {
       //! define the contribution from a neighbour atom to the expansion
       template <AtomicSmearingType AST, size_t Order, size_t Layer>
       Matrix_Ref
-      compute_neighbour_contribution(const double & distance,
+      compute_neighbour_contribution(double distance,
                                      ClusterRefKey<Order, Layer> & pair) {
         using math::PI;
         using math::pow;
@@ -727,7 +727,7 @@ namespace rascal {
        */
       template <AtomicSmearingType AST, size_t Order, size_t Layer>
       Matrix_Ref
-      compute_neighbour_derivative(const double & /*distance*/,
+      compute_neighbour_derivative(double /*distance*/,
                                    ClusterRefKey<Order, Layer> & /*pair*/) {
         using math::PI;
         using math::pow;

--- a/src/representations/cutoff_functions.hh
+++ b/src/representations/cutoff_functions.hh
@@ -69,10 +69,10 @@ namespace rascal {
 
       // TODO(felix) test is having these pure virtual changes performance
       //! Pure Virtual Function to evaluate the cutoff function
-      // virtual double f_c(const double& distance) = 0;
+      // virtual double f_c(double distance) = 0;
       //! Pure Virtual Function to evaluate the derivative of the cutoff
       //! function with respect to the distance
-      // virtual double df_c(const double& distance) = 0;
+      // virtual double df_c(double distance) = 0;
     };
 
     // Empty general template class implementing the cutoff functions
@@ -94,12 +94,12 @@ namespace rascal {
             hypers.at("smooth_width").at("value").get<double>();
       }
 
-      inline double f_c(const double & distance) {
+      inline double f_c(double distance) {
         return math::switching_function_cosine(distance, this->cutoff,
                                                this->smooth_width);
       }
 
-      inline double df_c(const double & distance) {
+      inline double df_c(double distance) {
         return math::derivative_switching_funtion_cosine(distance, this->cutoff,
                                                          this->smooth_width);
       }
@@ -152,7 +152,7 @@ namespace rascal {
         this->scale = hypers.at("scale").at("value").get<double>();
       }
 
-      inline double f_c(const double & distance) {
+      inline double f_c(double distance) {
         double factor{0.};
         if (this->rate > math::dbl_ftol) {
           factor = this->rate / (this->rate + math::pow(distance / this->scale,
@@ -166,7 +166,7 @@ namespace rascal {
                                                         this->smooth_width);
       }
 
-      inline double df_c(const double & distance) {
+      inline double df_c(double distance) {
         double factor{0.};
         if (this->rate < math::dbl_ftol) {
           factor = -this->exponent / distance *

--- a/src/structure_managers/adaptor_center_contribution.hh
+++ b/src/structure_managers/adaptor_center_contribution.hh
@@ -153,7 +153,7 @@ namespace rascal {
       return this->get_nb_clusters(1);
     }
 
-    inline Vector_ref get_position(const int & index) {
+    inline Vector_ref get_position(int index) {
       return this->manager->get_position(index);
     }
 
@@ -194,7 +194,7 @@ namespace rascal {
     }
 
     //! return atom type
-    inline const int & get_atom_type(const AtomRef_t & atom) const {
+    inline int get_atom_type(const AtomRef_t & atom) const {
       // careful, atom refers to our local index, for the manager, we need its
       // index:
       auto && original_atom{this->atom_tag_list[0][atom.get_index()]};
@@ -202,12 +202,12 @@ namespace rascal {
     }
 
     //! Returns atom type given an atom tag
-    inline int & get_atom_type(const int & atom_id) {
+    inline int & get_atom_type(int atom_id) {
       return this->manager->get_atom_type(atom_id);
     }
 
     //! Returns a constant atom type given an atom tag
-    inline const int & get_atom_type(const int & atom_id) const {
+    inline int get_atom_type(int atom_id) const {
       auto && type{this->manager->get_atom_type(atom_id)};
       return type;
     }

--- a/src/structure_managers/adaptor_filter.hh
+++ b/src/structure_managers/adaptor_filter.hh
@@ -197,7 +197,7 @@ namespace rascal {
     /**
      * return the position of a given atom
      */
-    inline Vector_ref get_position(const int & index) {
+    inline Vector_ref get_position(int index) {
       return this->manager->get_position(index);
     }
 
@@ -268,7 +268,7 @@ namespace rascal {
     }
 
     //! return atom type
-    inline const int & get_atom_type(const AtomRef_t & atom) const {
+    inline int get_atom_type(const AtomRef_t & atom) const {
       // careful, atom refers to our local index, for the manager, we need its
       // index:
       auto && original_atom{this->atom_tag_list[0][atom.get_index()]};
@@ -276,13 +276,13 @@ namespace rascal {
     }
 
     //! Returns atom type given an atom tag
-    inline int & get_atom_type(const int & atom_id) {
+    inline int & get_atom_type(int atom_id) {
       auto && type{this->manager->get_atom_type(atom_id)};
       return type;
     }
 
     //! Returns a constant atom type given an atom tag
-    inline const int & get_atom_type(int & atom_id) const {
+    inline int get_atom_type(int & atom_id) const {
       auto && type{this->manager->get_atom_type(atom_id)};
       return type;
     }

--- a/src/structure_managers/adaptor_full_neighbour_list.hh
+++ b/src/structure_managers/adaptor_full_neighbour_list.hh
@@ -165,7 +165,7 @@ namespace rascal {
     }
 
     //! returns position of the given atom tag
-    inline Vector_ref get_position(const int & index) {
+    inline Vector_ref get_position(int index) {
       return this->manager->get_position(index);
     }
 
@@ -210,17 +210,17 @@ namespace rascal {
     }
 
     //! return atom type, const ref
-    inline const int & get_atom_type(const AtomRef_t & atom) const {
+    inline int get_atom_type(const AtomRef_t & atom) const {
       return this->manager->get_atom_type(atom.get_index());
     }
 
     //! Returns atom type given an atom tag
-    inline int & get_atom_type(const int & atom_id) {
+    inline int & get_atom_type(int atom_id) {
       return this->manager->get_atom_type(atom_id);
     }
 
     //! Returns a constant atom type given an atom tag
-    inline const int & get_atom_type(const int & atom_id) const {
+    inline int get_atom_type(int atom_id) const {
       return this->manager->get_atom_type(atom_id);
     }
 

--- a/src/structure_managers/adaptor_half_neighbour_list.hh
+++ b/src/structure_managers/adaptor_half_neighbour_list.hh
@@ -166,7 +166,7 @@ namespace rascal {
     }
 
     //! returns position of the given atom tag
-    inline Vector_ref get_position(const int & index) {
+    inline Vector_ref get_position(int index) {
       return this->manager->get_position(index);
     }
 
@@ -211,17 +211,17 @@ namespace rascal {
     }
 
     //! return atom type, const ref
-    inline const int & get_atom_type(const AtomRef_t & atom) const {
+    inline int get_atom_type(const AtomRef_t & atom) const {
       return this->manager->get_atom_type(atom.get_index());
     }
 
     //! Returns atom type given an atom tag
-    inline int & get_atom_type(const int & atom_id) {
+    inline int & get_atom_type(int atom_id) {
       return this->manager->get_atom_type(atom_id);
     }
 
     //! Returns a constant atom type given an atom tag
-    inline const int & get_atom_type(const int & atom_id) const {
+    inline int get_atom_type(int atom_id) const {
       return this->manager->get_atom_type(atom_id);
     }
 

--- a/src/structure_managers/adaptor_increase_maxorder.hh
+++ b/src/structure_managers/adaptor_increase_maxorder.hh
@@ -174,7 +174,7 @@ namespace rascal {
     inline size_t get_size() const { return this->manager->get_size(); }
 
     //! Returns position of an atom with index atom_tag
-    inline Vector_ref get_position(const size_t & atom_tag) {
+    inline Vector_ref get_position(size_t atom_tag) {
       return this->manager->get_position(atom_tag);
     }
 
@@ -184,12 +184,12 @@ namespace rascal {
     }
 
     //! get atom type from underlying manager
-    inline const int & get_atom_type(const int & atom_tag) const {
+    inline int get_atom_type(int atom_tag) const {
       return this->manager->get_atom_type(atom_tag);
     }
 
     //! get atom type from underlying manager
-    inline int & get_atom_type(const int & atom_tag) {
+    inline int & get_atom_type(int atom_tag) {
       return this->manager->get_atom_type(atom_tag);
     }
 

--- a/src/structure_managers/adaptor_neighbour_list.hh
+++ b/src/structure_managers/adaptor_neighbour_list.hh
@@ -165,7 +165,7 @@ namespace rascal {
       //! constructor
       PeriodicImages(const std::array<int, Dim> & origin,
                      const std::array<int, Dim> & nrepetitions,
-                     const size_t & ntot)
+                     size_t ntot)
           : origin{origin}, nrepetitions{nrepetitions}, ntot{ntot} {}
       //! copy constructor
       PeriodicImages(const PeriodicImages & other) = default;
@@ -321,7 +321,7 @@ namespace rascal {
     /* ---------------------------------------------------------------------- */
     //! get the cell index for a position
     template <class Vector_t>
-    decltype(auto) get_box_index(const Vector_t & position, const double & rc) {
+    decltype(auto) get_box_index(const Vector_t & position, double rc) {
       auto constexpr dimension{Vector_t::SizeAtCompileTime};
 
       std::array<int, dimension> nidx{};
@@ -565,7 +565,7 @@ namespace rascal {
     }
 
     //! Returns position of an atom with index atom_tag
-    inline Vector_ref get_position(const size_t & atom_tag) {
+    inline Vector_ref get_position(size_t atom_tag) {
       if (atom_tag < this->n_atoms) {
         return this->manager->get_position(atom_tag);
       } else {
@@ -586,13 +586,13 @@ namespace rascal {
     }
 
     //! ghost types are only available for MaxOrder=2
-    inline const int & get_ghost_type(const size_t & atom_tag) const {
+    inline int get_ghost_type(size_t atom_tag) const {
       auto && p{this->get_ghost_types()};
       return p[atom_tag];
     }
 
     //! ghost types are only available for MaxOrder=2
-    inline int & get_ghost_type(const size_t & atom_tag) {
+    inline int & get_ghost_type(size_t atom_tag) {
       auto && p{this->get_ghost_types()};
       return p[atom_tag];
     }
@@ -644,7 +644,7 @@ namespace rascal {
     }
 
     //! Returns atom type given an atom tag, also works for ghost atoms
-    inline int & get_atom_type(const int & atom_tag) {
+    inline int & get_atom_type(int atom_tag) {
       // return this->atom_types[this->get_atom_index(atom_tag)];
       return this->atom_types[atom_tag];
     }
@@ -658,7 +658,7 @@ namespace rascal {
     }
 
     //! Returns the type of a given atom, given an AtomRef
-    inline const int & get_atom_type(const int & atom_tag) const {
+    inline int get_atom_type(int atom_tag) const {
       return this->atom_types[atom_tag];
     }
 
@@ -678,9 +678,9 @@ namespace rascal {
       return this->manager->get_shared_ptr();
     }
 
-    const size_t & get_n_update() const { return this->n_update; }
+    size_t get_n_update() const { return this->n_update; }
 
-    const size_t & get_skin2() const { return this->skin2; }
+    size_t get_skin2() const { return this->skin2; }
 
    protected:
     /* ---------------------------------------------------------------------- */
@@ -698,8 +698,8 @@ namespace rascal {
      * is needed, because ghost atoms are also included in the buildup of the
      * pair list.
      */
-    inline void add_ghost_atom(const int & atom_tag, const Vector_t & position,
-                               const int & atom_type) {
+    inline void add_ghost_atom(int atom_tag, const Vector_t & position,
+                               int atom_type) {
       // first add it to the list of atoms
       this->atom_tag_list.push_back(atom_tag);
       this->atom_types.push_back(atom_type);

--- a/src/structure_managers/adaptor_strict.hh
+++ b/src/structure_managers/adaptor_strict.hh
@@ -147,7 +147,7 @@ namespace rascal {
       return this->get_nb_clusters(1);
     }
 
-    inline Vector_ref get_position(const int & index) {
+    inline Vector_ref get_position(int index) {
       return this->manager->get_position(index);
     }
 
@@ -188,7 +188,7 @@ namespace rascal {
     }
 
     //! return atom type
-    inline const int & get_atom_type(const AtomRef_t & atom) const {
+    inline int get_atom_type(const AtomRef_t & atom) const {
       // careful, atom refers to our local index, for the manager, we need its
       // index:
       auto && original_atom{this->atom_tag_list[0][atom.get_index()]};
@@ -196,12 +196,12 @@ namespace rascal {
     }
 
     //! Returns atom type given an atom tag
-    inline int & get_atom_type(const int & atom_id) {
+    inline int & get_atom_type(int atom_id) {
       return this->manager->get_atom_type(atom_id);
     }
 
     //! Returns a constant atom type given an atom tag
-    inline const int & get_atom_type(const int & atom_id) const {
+    inline int get_atom_type(int atom_id) const {
       auto && type{this->manager->get_atom_type(atom_id)};
       return type;
     }

--- a/src/structure_managers/cluster_ref_key.hh
+++ b/src/structure_managers/cluster_ref_key.hh
@@ -237,18 +237,18 @@ namespace rascal {
     }
 
     //! returns the first atom tag in this cluster
-    const int & front() const { return this->atom_tag_list.front(); }
+    int front() const { return this->atom_tag_list.front(); }
     //! returns the last atom tag in this cluster
-    const int & back() const { return this->atom_tag_list.back(); }
+    int back() const { return this->atom_tag_list.back(); }
     /* the internal cluster neighbour is the neighbour which was added as
      * neighbour in the creation of this cluster
      */
-    const int & get_internal_neighbour_atom_tag() const { return this->back(); }
+    int get_internal_neighbour_atom_tag() const { return this->back(); }
 
     /*
      * From an cluster of form (i,j,..., n) it returns the tag of atom n
      */
-    const int & get_atom_tag() const { return this->back(); }
+    int get_atom_tag() const { return this->back(); }
 
     //! returns the cluster's index, given a specific layer
     inline size_t get_cluster_index(const size_t layer) const {

--- a/src/structure_managers/property.hh
+++ b/src/structure_managers/property.hh
@@ -173,7 +173,7 @@ namespace rascal {
     /**
      * Accessor for property by index for properties
      */
-    inline reference operator[](const size_t & index) {
+    inline reference operator[](size_t index) {
       // use tag dispatch to use the proper definition
       // of the get function
       return this->get(
@@ -205,11 +205,11 @@ namespace rascal {
                             this->get_nb_col());
     }
 
-    inline reference get(const size_t & index, StaticSize) {
+    inline reference get(size_t index, StaticSize) {
       return Value::get_ref(this->values[index * NbRow * NbCol]);
     }
 
-    inline reference get(const size_t & index, DynamicSize) {
+    inline reference get(size_t index, DynamicSize) {
       return get_ref(this->values[index * this->get_nb_comp()]);
     }
 

--- a/src/structure_managers/property_base.hh
+++ b/src/structure_managers/property_base.hh
@@ -109,9 +109,9 @@ namespace rascal {
     /**
      * Controls the is_updated flag
      */
-    inline const bool & is_updated() const { return this->updated; }
+    inline bool is_updated() const { return this->updated; }
 
-    inline void set_updated_status(const bool & is_updated) {
+    inline void set_updated_status(bool is_updated) {
       this->updated = is_updated;
     }
 

--- a/src/structure_managers/property_block_sparse.hh
+++ b/src/structure_managers/property_block_sparse.hh
@@ -93,7 +93,7 @@ namespace rascal {
       }
 
       //! access or insert specified element. use with caution !
-      inline Value_t & operator[](const size_t & id) { return this->data[id]; }
+      inline Value_t & operator[](size_t id) { return this->data[id]; }
 
       inline const Key_t & get_key() const { return data; }
     };
@@ -276,14 +276,14 @@ namespace rascal {
        * the elements
        */
       template <typename Key_List>
-      void resize(const Key_List & keys, const int & n_row, const int & n_col,
+      void resize(const Key_List & keys, int n_row, int n_col,
                   const Precision_t & val) {
         this->resize(keys, n_row, n_col);
         this->data = val;
       }
 
       template <typename Key_List>
-      void resize(const Key_List & keys, const int & n_row, const int & n_col) {
+      void resize(const Key_List & keys, int n_row, int n_col) {
         std::vector<SortedKey_t> skeys{};
         for (auto && key : keys) {
           SortedKey_t skey{key};
@@ -292,8 +292,8 @@ namespace rascal {
         this->resize(skeys, n_row, n_col);
       }
 
-      void resize(const std::vector<SortedKey_t> & skeys, const int & n_row,
-                  const int & n_col) {
+      void resize(const std::vector<SortedKey_t> & skeys, int n_row,
+                  int n_col) {
         int new_size{0};
         for (auto && skey : skeys) {
           if (this->count(skey) == 0) {
@@ -334,7 +334,7 @@ namespace rascal {
         return keys;
       }
 
-      inline void multiply_elements_by(const double & fac) {
+      inline void multiply_elements_by(double fac) {
         this->data *= fac;
       }
 
@@ -363,7 +363,7 @@ namespace rascal {
        *
        * relevant only when the keys have 2 indices
        */
-      inline void multiply_off_diagonal_elements_by(const double & fac) {
+      inline void multiply_off_diagonal_elements_by(double fac) {
         for (const auto & el : this->map) {
           auto && pair_type{el.first};
           auto && pos{el.second};
@@ -599,7 +599,7 @@ namespace rascal {
     }
 
     //! Accessor for property by index for dynamically sized properties
-    inline InputData_t & operator[](const size_t & index) {
+    inline InputData_t & operator[](size_t index) {
       return this->values[index];
     }
 
@@ -615,7 +615,7 @@ namespace rascal {
     }
 
     //! Accessor for property by index for dynamically sized properties
-    inline DenseRef_t operator()(const size_t & index, const Key_t & key) {
+    inline DenseRef_t operator()(size_t index, const Key_t & key) {
       auto && val = this->values[index].at(key);
       return DenseRef_t(&val(0, 0), val.rows(), val.cols());
     }
@@ -632,7 +632,7 @@ namespace rascal {
       return this->get_dense_row(id.get_cluster_index(CallerLayer));
     }
 
-    inline Matrix_t get_dense_row(const size_t & index) {
+    inline Matrix_t get_dense_row(size_t index) {
       auto keys = this->values[index].get_keys();
       Matrix_t feature_row = Matrix_t::Zero(this->get_nb_comp(), keys.size());
       size_t i_col{0};

--- a/src/structure_managers/property_typed.hh
+++ b/src/structure_managers/property_typed.hh
@@ -279,7 +279,7 @@ namespace rascal {
     }
 
     //! Accessor for property by index for dynamically sized properties
-    reference operator[](const size_t & index) {
+    reference operator[](size_t index) {
       return Value_t::get_ref(this->values[index * this->get_nb_comp()],
                               this->get_nb_row(), this->get_nb_col());
     }

--- a/src/structure_managers/structure_manager.hh
+++ b/src/structure_managers/structure_manager.hh
@@ -316,7 +316,7 @@ namespace rascal {
     }
 
     //! returns position of an atom with index ``atom_tag``
-    inline Vector_ref position(const int & atom_tag) {
+    inline Vector_ref position(int atom_tag) {
       return this->implementation().get_position(atom_tag);
     }
 
@@ -327,13 +327,13 @@ namespace rascal {
 
     //! returns the atom type (convention is atomic number, but nothing is
     //! imposed apart from being an integer
-    inline const int & atom_type(const int & atom_tag) const {
+    inline int atom_type(int atom_tag) const {
       return this->implementation().get_atom_type(atom_tag);
     }
 
     //! returns the atom type (convention is atomic number, but nothing is
     //! imposed apart from being an integer
-    inline int & atom_type(const int & atom_tag) {
+    inline int & atom_type(int atom_tag) {
       return this->implementation().get_atom_type(atom_tag);
     }
 
@@ -484,7 +484,7 @@ namespace rascal {
               name);
     }
 
-    inline void set_updated_property_status(const bool & is_updated) {
+    inline void set_updated_property_status(bool is_updated) {
       for (auto & element : this->properties) {
         auto & property{element.second};
         property->set_updated_status(is_updated);
@@ -492,7 +492,7 @@ namespace rascal {
     }
 
     inline void set_updated_property_status(const std::string & name,
-                                            const bool & is_updated) {
+                                            bool is_updated) {
       this->properties[name]->set_updated_status(is_updated);
     }
 
@@ -759,7 +759,7 @@ namespace rascal {
       template <typename ClusterIndicesType_ = ClusterIndicesType,
                 typename std::enable_if_t<
                     std::is_same<ClusterIndicesType_, size_t>::value, int> = 0>
-      static inline IndexConstArray_t cast(const size_t & cluster_index) {
+      static inline IndexConstArray_t cast(const size_t& cluster_index) {
         return IndexConstArray_t(&cluster_index);
       }
     };
@@ -782,7 +782,7 @@ namespace rascal {
     AtomRef() = delete;
 
     //! constructor from iterator
-    AtomRef(Manager_t & manager, const int & id)
+    AtomRef(Manager_t & manager, int id)
         : manager{manager}, index{id} {}
 
     //! Copy constructor
@@ -801,7 +801,7 @@ namespace rascal {
     AtomRef & operator=(AtomRef && other) = default;
 
     //! return index of the atom
-    inline const int & get_index() const { return this->index; }
+    inline int get_index() const { return this->index; }
 
     //! return position vector of the atom
     inline Vector_ref get_position() {
@@ -812,7 +812,7 @@ namespace rascal {
      * return atom type (idea: corresponding atomic number, but is allowed
      * to be arbitrary as long as it is an integer)
      */
-    inline const int & get_atom_type() const {
+    inline int get_atom_type() const {
       return this->manager.atom_type(this->index);
     }
     /**
@@ -995,7 +995,7 @@ namespace rascal {
     }
 
     //! returns the type of the last atom in the cluster
-    inline const int & get_atom_type() const {
+    inline int get_atom_type() const {
       auto && id{this->get_atom_tag()};
       return this->get_manager().atom_type(id);
     }

--- a/src/structure_managers/structure_manager_centers.hh
+++ b/src/structure_managers/structure_manager_centers.hh
@@ -199,13 +199,13 @@ namespace rascal {
     inline Cell_ref get_cell() { return Cell_ref(this->atoms_object.cell); }
 
     //! Returns the type of a given atom, given an AtomRef
-    inline int & get_atom_type(const int & atom_tag) {
+    inline int & get_atom_type(int atom_tag) {
       auto && atom_index{this->get_atom_index(atom_tag)};
       return this->atoms_object.atom_types(atom_index);
     }
 
     //! Returns the type of a given atom, given an AtomRef
-    inline const int & get_atom_type(const int & atom_tag) const {
+    inline int get_atom_type(int atom_tag) const {
       auto && atom_index{this->get_atom_index(atom_tag)};
       return this->atoms_object.atom_types(atom_index);
     }
@@ -238,7 +238,7 @@ namespace rascal {
     }
 
     //! Returns the position of an atom, given an atom tag
-    inline Vector_ref get_position(const int & atom_tag) {
+    inline Vector_ref get_position(int atom_tag) {
       auto && atom_index{this->get_atom_index(atom_tag)};
       auto p = this->get_positions();
       auto * xval{p.col(atom_index).data()};
@@ -272,7 +272,7 @@ namespace rascal {
       return this->get_atom_index(cluster.get_atom_tag());
     }
 
-    inline const size_t & get_atom_index(const int & atom_tag) const {
+    inline size_t get_atom_index(int atom_tag) const {
       return std::get<0>(this->atoms_index)[atom_tag];
     }
 
@@ -294,9 +294,9 @@ namespace rascal {
       return 0;
     }
 
-    inline int get_atom_tag(const int & raw_index) const { return raw_index; }
+    inline int get_atom_tag(int raw_index) const { return raw_index; }
 
-    inline size_t get_atom_tag(const size_t & raw_index) const {
+    inline size_t get_atom_tag(size_t raw_index) const {
       return raw_index;
     }
 

--- a/src/structure_managers/structure_manager_collection.hh
+++ b/src/structure_managers/structure_manager_collection.hh
@@ -204,7 +204,7 @@ namespace rascal {
      * first and 3 would corresponds to the 4th structure irrespective of the
      * actual indices in the file.
      */
-    void add_structures(const std::string & filename, const int & start = 0,
+    void add_structures(const std::string & filename, int start = 0,
                         int length = -1) {
       // important not to do brace initialization because it adds an extra
       // nesting layer

--- a/src/structure_managers/structure_manager_lammps.cc
+++ b/src/structure_managers/structure_manager_lammps.cc
@@ -33,8 +33,8 @@
 namespace rascal {
 
   /* ---------------------------------------------------------------------- */
-  void StructureManagerLammps::update_self(const int & inum,
-                                           const int & tot_num, int * ilist,
+  void StructureManagerLammps::update_self(int inum,
+                                           int tot_num, int * ilist,
                                            int * numneigh, int ** firstneigh,
                                            double ** x, double ** f, int * type,
                                            double * eatom, double ** vatom) {

--- a/src/structure_managers/structure_manager_lammps.hh
+++ b/src/structure_managers/structure_manager_lammps.hh
@@ -104,7 +104,7 @@ namespace rascal {
     }
 
     //! return position vector of an atom given the atom tag
-    inline Vector_ref get_position(const int & atom_tag) {
+    inline Vector_ref get_position(int atom_tag) {
       auto * xval{this->x[this->get_atom_index(atom_tag)]};
       return Vector_ref(xval);
     }
@@ -115,12 +115,12 @@ namespace rascal {
     }
 
     //! get const atom type reference given an atom_tag
-    inline const int & get_atom_type(const int & atom_tag) const {
+    inline int get_atom_type(int atom_tag) const {
       return this->type[this->get_atom_index(atom_tag)];
     }
 
     //! Returns atom type given an atom tag
-    inline int & get_atom_type(const int & atom_tag) {
+    inline int & get_atom_type(int atom_tag) {
       return this->type[this->get_atom_index(atom_tag)];
     }
 
@@ -219,7 +219,7 @@ namespace rascal {
      *
      * @param vatom per-atom virial
      */
-    void update_self(const int & inum, const int & tot_num, int * ilist,
+    void update_self(int inum, int tot_num, int * ilist,
                      int * numneigh, int ** firstneigh, double ** x,
                      double ** f, int * type, double * eatom, double ** vatom);
 

--- a/src/utils/key_standardisation.hh
+++ b/src/utils/key_standardisation.hh
@@ -78,7 +78,7 @@ namespace rascal {
 
     const T & operator[](const size_t index) const { return this->key[index]; }
 
-    const size_t & get_order() const { return this->order; }
+    size_t get_order() const { return this->order; }
 
     const T & back() const { return key.back(); }
 


### PR DESCRIPTION
This is less clear and can be less efficient (`const bool&` is pointer sized, `bool` is 1/4 or 1/8 of this)