### PR TITLE
Python interface for selecting centres

### DIFF
--- a/bindings/rascal/neighbourlist/structure_manager.py
+++ b/bindings/rascal/neighbourlist/structure_manager.py
@@ -263,5 +263,7 @@ def mask_center_atoms_by_species(frame, species_select=[],
             old_mask = np.ones((frame.get_number_of_atoms(),), dtype='bool')
     else:
         old_mask = frame.arrays['center_atoms_mask']
+    # Python's "bitwise" operators do per-element logical operations in NumPy
+    # see for instance https://docs.scipy.org/doc/numpy/reference/ufuncs.html#comparison-functions
     mask = (old_mask | id_select) & ~id_blacklist
     frame.arrays['center_atoms_mask'] = mask

--- a/bindings/rascal/neighbourlist/structure_manager.py
+++ b/bindings/rascal/neighbourlist/structure_manager.py
@@ -154,18 +154,24 @@ def add_center_atoms_mask_by_id(frame, id_select=None, id_blacklist=None):
     ----------
     frame: ase.Atoms
         Atomic structure to mask
+
     id_select: list of int
         List of atom IDs to select
+
     id_blacklist: list of int
         List of atom IDs to exclude
 
-    The default is to select all atoms.  If id_select is provided,
-    select only those atoms.  If only id_blacklist is provided, select
-    all atoms _except_ those in the blacklist.  If both are provided,
-    atoms are first selected based on id_select and then excluded based
-    on id_blacklist.
+    Returns
+    -------
+    None (the Atoms object is modified directly)
 
-    The Atoms object is modified directly; nothing is returned.
+    Notes
+    -----
+    The default is to select all atoms.  If `id_select` is provided,
+    select only those atoms.  If only `id_blacklist` is provided, select
+    all atoms *except* those in the blacklist.  If both are provided,
+    atoms are first selected based on `id_select` and then excluded based
+    on `id_blacklist`.
     """
     if id_select is not None:
         atoms_select = np.arange(frame.get_number_of_atoms())
@@ -186,21 +192,27 @@ def add_center_atoms_mask_species(frame, species_select=[],
     ----------
     frame: ase.Atoms
         Atomic structure to mask
+
     species_select: list of int or str
-        List of atomic numbers, or species symbols, to select
-        Should be of consistent type across list
+        List of atomic numbers, or species symbols, to select.
+        Should be of consistent type across list.
+
     species_blacklist: list of int or str
-        List of atomic numbers, or species symbols, to exclude
-        Should be of consistent type across list
+        List of atomic numbers, or species symbols, to exclude.
+        Should be of consistent type across list.
 
-    The default is to select all atoms.  If species_select is provided,
+    Returns
+    -------
+    None (the Atoms object is modified directly)
+
+    Notes
+    -----
+    The default is to select all atoms.  If `species_select` is provided,
     select only those atoms whose species is in the list.  If only
-    species_blacklist is provided, select all atoms _except_ those whose
+    `species_blacklist` is provided, select all atoms *except* those whose
     species is in the blacklist.  If both are provided, atoms are first
-    selected based on species_select and then excluded based
-    on species_blacklist.
-
-    The Atoms object is modified directly; nothing is returned.
+    selected based on `species_select` and then excluded based
+    on `species_blacklist`.
     """
     select_is_str = reduce(and_,
                            map(lambda x: isinstance(x, str), species_select))

--- a/docs/source/reference/python.rst
+++ b/docs/source/reference/python.rst
@@ -9,9 +9,9 @@ This list is incomplete. You can help by *expanding it*!
 Atoms and cells
 ===============
 
-.. autofunction:: rascal.neighbourlist.structure_manager.add_center_atoms_mask_by_id
+.. autofunction:: rascal.neighbourlist.structure_manager.mask_center_atoms_by_id
 
-.. autofunction:: rascal.neighbourlist.structure_manager.add_center_atoms_mask_species
+.. autofunction:: rascal.neighbourlist.structure_manager.mask_center_atoms_by_species
 
 Representations
 ===============

--- a/docs/source/reference/python.rst
+++ b/docs/source/reference/python.rst
@@ -6,5 +6,21 @@ Python
 
 This list is incomplete. You can help by *expanding it*!
 
+Atoms and cells
+===============
+
+.. autofunction:: rascal.neighbourlist.structure_manager.add_center_atoms_mask_by_id
+
+.. autofunction:: rascal.neighbourlist.structure_manager.add_center_atoms_mask_species
+
+Representations
+===============
+
 .. autoclass:: rascal.representations.SortedCoulombMatrix
+   :members:
+
+.. autoclass:: rascal.representations.SphericalInvariants
+   :members:
+
+.. autoclass:: rascal.representations.SphericalCovariants
    :members:

--- a/examples/center_select_example.py
+++ b/examples/center_select_example.py
@@ -1,18 +1,30 @@
 #!/usr/bin/env python
 """Example for selecting centres by species
 
-This computes the SphericalInvariants on a small-molecule test set"""
+This computes the SphericalInvariants on a small-molecule test set, selecting
+only carbon centres
+"""
+
 
 import ase.io
-from rascal.representations import SphericalInvariants
-from rascal.neighbourlist.structure_manager import add_center_atoms_mask_species
+import numpy as np
 
-molecules = ase.io.read('data/small_molecules-1000.xyz', ':')
+from rascal.representations import SphericalInvariants
+from rascal.neighbourlist.structure_manager import (
+        mask_center_atoms_by_species, mask_center_atoms_by_id)
+
+
+molecules = ase.io.read('data/small_molecules-1000.xyz', ':100')
+n_centers = sum(mol.get_number_of_atoms() for mol in molecules)
+n_carbon_centers = sum(np.sum(mol.get_atomic_numbers() == 6)
+                       for mol in molecules)
+print("{:d} molecules, {:d} centres total, {:d} carbon centres".format(
+    len(molecules), n_centers, n_carbon_centers))
 
 for molecule in molecules:
-    add_center_atoms_mask_species(molecule, species_select=['C',])
+    mask_center_atoms_by_species(molecule, species_select=['C',])
     # Also works by atomic number
-    #add_center_atoms_mask_species(molecule, species_select=[6,])
+    #mask_center_atoms_by_species(molecule, species_select=[6,])
 
 hypers = {'interaction_cutoff': 5.0,
           'cutoff_smooth_width': 0.5,
@@ -22,5 +34,17 @@ hypers = {'interaction_cutoff': 5.0,
           'gaussian_sigma_constant': 0.3}
 
 representation = SphericalInvariants(**hypers)
-soap_vectors = representation.transform(molecules)
-print(soap_vectors.get_dense_feature_matrix().shape)
+atoms_transformed = representation.transform(molecules)
+print("Number of feature vectors computed: {:d}".format(
+    atoms_transformed.get_dense_feature_matrix(representation).shape[0]))
+
+print("Now masking out the first 5 atoms of each molecule.")
+n_remaining_centers = sum(np.sum((mol.get_atomic_numbers()[5:] == 6))
+                          for mol in molecules)
+print("Number of centres remaining: {:d}".format(n_remaining_centers))
+
+for molecule in molecules:
+    mask_center_atoms_by_id(molecule, id_blacklist=np.arange(5))
+atoms_transformed = representation.transform(molecules)
+print("Number of feature vectors computed: {:d}".format(
+    atoms_transformed.get_dense_feature_matrix(representation).shape[0]))

--- a/examples/center_select_example.py
+++ b/examples/center_select_example.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+"""Example for selecting centres by species
+
+This computes the SphericalInvariants on a small-molecule test set"""
+
+import ase.io
+from rascal.representations import SphericalInvariants
+from rascal.neighbourlist.structure_manager import add_center_atoms_mask_species
+
+molecules = ase.io.read('data/small_molecules-1000.xyz', ':')
+
+for molecule in molecules:
+    add_center_atoms_mask_species(molecule, species_select=['C',])
+    # Also works by atomic number
+    #add_center_atoms_mask_species(molecule, species_select=[6,])
+
+hypers = {'interaction_cutoff': 5.0,
+          'cutoff_smooth_width': 0.5,
+          'max_radial': 8,
+          'max_angular': 6,
+          'gaussian_sigma_type': "Constant",
+          'gaussian_sigma_constant': 0.3}
+
+representation = SphericalInvariants(**hypers)
+soap_vectors = representation.transform(molecules)
+print(soap_vectors.get_dense_feature_matrix().shape)

--- a/tests/python/python_binding_tests.py
+++ b/tests/python/python_binding_tests.py
@@ -4,7 +4,7 @@ import unittest
 import faulthandler
 
 from python_structure_manager_test import (
-    TestStructureManagerCenters, TestNL, TestNLStrict
+    TestStructureManagerCenters, TestNL, TestNLStrict, CenterSelectTest
 )
 from python_representation_calculator_test import (
     TestSortedCoulombRepresentation, TestSphericalExpansionRepresentation,

--- a/tests/python/python_structure_manager_test.py
+++ b/tests/python/python_structure_manager_test.py
@@ -1,4 +1,8 @@
+import ase.io
+
 from rascal.neighbourlist import get_neighbourlist
+from rascal.neighbourlist.structure_manager import (
+        mask_center_atoms_by_species, mask_center_atoms_by_id)
 from test_utils import load_json_frame, BoxList, Box
 import unittest
 import numpy as np
@@ -195,3 +199,106 @@ class TestNLStrict(unittest.TestCase):
                 # sort because the order is not the same
                 ref_sort_ids, sort_ids = np.argsort(
                     ref_dists), np.argsort(dists)
+
+class CenterSelectTest(unittest.TestCase):
+
+    """Test the center-select Python interface
+
+    Make sure it produces the right masks for a variety of inputs
+    """
+
+    def setUp(self):
+        filename = 'reference_data/small_molecule.json'
+        self.frame = ase.io.read(filename)
+        self.natoms = self.frame.get_number_of_atoms()
+
+    def get_mask(self):
+        return self.frame.arrays['center_atoms_mask']
+
+    def check_mask(self, test_mask):
+        self.assertTrue(np.all(self.get_mask() == test_mask))
+
+    def test_mask_id_select(self):
+        mask_center_atoms_by_id(self.frame, np.arange(5))
+        test_mask = np.zeros((self.natoms,), dtype='bool')
+        test_mask[:5] = True
+        self.check_mask(test_mask)
+        # Now try it with an existing mask
+        mask_center_atoms_by_id(self.frame, np.arange(3, 7))
+        test_mask[:7] = True
+        self.check_mask(test_mask)
+        mask_center_atoms_by_id(self.frame, id_blacklist=[0,])
+        test_mask[0] = False
+        self.check_mask(test_mask)
+
+    def test_mask_id_blacklist(self):
+        mask_center_atoms_by_id(self.frame, id_blacklist=np.arange(5))
+        test_mask = np.ones((self.natoms,), dtype='bool')
+        test_mask[:5] = False
+        self.check_mask(test_mask)
+        mask_center_atoms_by_id(self.frame, id_blacklist=np.arange(3, 7))
+        test_mask[:7] = False
+        self.check_mask(test_mask)
+        mask_center_atoms_by_id(self.frame, id_select=[0,])
+        test_mask[0] = True
+        self.check_mask(test_mask)
+
+    def test_mask_id_both(self):
+        mask_center_atoms_by_id(self.frame, id_select=np.arange(7),
+                                id_blacklist=np.arange(3, 9))
+        test_mask = np.zeros((self.natoms,), dtype='bool')
+        test_mask[:3] = True
+        self.check_mask(test_mask)
+
+    def test_mask_species_select(self):
+        mask_center_atoms_by_species(self.frame, ['C', 'H'])
+        test_mask = np.array([0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 1], dtype='bool')
+        self.check_mask(test_mask)
+        mask_center_atoms_by_species(self.frame, ['N',])
+        test_mask[[0, 2, 4, 6]] = True
+        self.check_mask(test_mask)
+        mask_center_atoms_by_species(self.frame, species_blacklist=['H',])
+        test_mask[[9, 10]] = False
+        self.check_mask(test_mask)
+
+    def test_mask_species_blacklist(self):
+        mask_center_atoms_by_species(self.frame, species_blacklist=['C', 'H'])
+        test_mask = np.array([1, 0, 1, 0, 1, 1, 1, 1, 1, 0, 0], dtype='bool')
+        self.check_mask(test_mask)
+        mask_center_atoms_by_species(self.frame, species_blacklist=['N',])
+        test_mask[[0, 2, 4, 6]] = False
+        self.check_mask(test_mask)
+        mask_center_atoms_by_species(self.frame, species_select=['H',])
+        test_mask[[9, 10]] = True
+        self.check_mask(test_mask)
+
+    def test_mask_species_both(self):
+        mask_center_atoms_by_species(self.frame, species_select=['C', 'N'],
+                                     species_blacklist=['N', 'H'])
+        test_mask = np.array([0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0], dtype='bool')
+        self.check_mask(test_mask)
+
+    def test_mask_species_numeric(self):
+        # Can also select by atomic number
+        mask_center_atoms_by_species(self.frame, species_select=[1, 6])
+        test_mask = np.array([0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 1], dtype='bool')
+        self.check_mask(test_mask)
+
+    def test_mask_species_numeric_combined(self):
+        mask_center_atoms_by_species(self.frame, species_select=['C', 'N'],
+                                     species_blacklist=[7, 1])
+        test_mask = np.array([0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0], dtype='bool')
+        self.check_mask(test_mask)
+        # And check that mixed symbol-numeric lists are disallowed
+        with self.assertRaises(ValueError):
+            mask_center_atoms_by_species(self.frame, species_select=['C', 1])
+        with self.assertRaises(ValueError):
+            mask_center_atoms_by_species(self.frame,
+                                         species_blacklist=['C', 1])
+
+    def test_mask_species_and_id(self):
+        mask_center_atoms_by_species(self.frame, species_select=['C',])
+        mask_center_atoms_by_id(self.frame, id_blacklist=np.arange(3))
+        test_mask = np.zeros((self.natoms,), dtype='bool')
+        test_mask[3] = True
+        self.check_mask(test_mask)


### PR DESCRIPTION
Fix #148, in progress

Take advantage of the existing infrastructure in the Python bindings. Now you just have to process the atoms through one of these functions (we might also make convenience functions for operating on lists) and pass them to representation.transform() as usual.