### PR TITLE
Valgrind tutorial

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && \
         vim \
         python3.6 python3-pip \
         libboost-test-dev \
-        doxygen pandoc
+        doxygen pandoc \
+        valgrind
 
 # - "ppa:ubuntu-toolchain-r/test" is used for gcc-9
 # - "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main" is the

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 # indicated by the CC/CXX environment variables.
 default_job: &default_job
   docker:
-    - image: cosmoepfl/rascal-ci:1
+    - image: cosmoepfl/rascal-ci:2
   steps:
     - checkout
     - run:
@@ -27,9 +27,13 @@ default_job: &default_job
     - run:
         name: Run tests
         command: cd build && ctest --output-on-failure
+        # valgrind tests can take more than 10min
+        no_output_timeout: 20m
     - run:
-         name: Run benchmarks
-         command: cd build && make benchmarks
+        name: Run benchmarks
+        command: cd build && make benchmarks
+
+
 jobs:
   gcc-5:
     environment:
@@ -61,13 +65,18 @@ jobs:
     environment:
       CC: clang-9
       CXX: clang++-9
-      APT_EXTRA_INSTALL: apt install -y clang-9
       CMAKE_EXTRA: -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG=
+    <<: *default_job
+  valgrind:
+    environment:
+      CC: gcc-9
+      CXX: g++-9
+      CMAKE_EXTRA: -DRASCAL_TESTS_USE_VALGRIND=ON -DTYPE_ARCHITECTURE=core2
     <<: *default_job
   # Special job only building the documentation
   docs:
     docker:
-    - image: cosmoepfl/rascal-ci:1
+    - image: cosmoepfl/rascal-ci:2
     steps:
       - checkout
       - run:
@@ -94,7 +103,7 @@ jobs:
   # Special job only linting the code
   lint:
     docker:
-    - image: cosmoepfl/rascal-ci:1
+    - image: cosmoepfl/rascal-ci:2
     steps:
       - checkout
       - run:
@@ -116,6 +125,7 @@ workflows:
     jobs:
       - lint
       - docs
+      - valgrind
       - gcc-5
       - gcc-9
       - gcc-9-debug

--- a/README.rst
+++ b/README.rst
@@ -140,7 +140,7 @@ Tests
 ^^^^^
 
 Librascal source code is extensively tested (both c++ and python).
-The BOOST unit_test_framework is requiered to build the tests (see
+The BOOST unit_test_framework is required to build the tests (see
 BOOST.md for further details on how to install the boost library). To
 build and run the tests:
 
@@ -151,9 +151,12 @@ build and run the tests:
    make
    ctest -V
 
+You can also run the tests with Valgrind (a memory-error checker) by passing
+``-DRASCAL_TESTS_USE_VALGRIND=ON`` to ``cmake``.
+
 In addition to testing the behaviour of the code, the test suite also check
 for formatting compliance with the clang-format and autopep8 packages (these
-dependencies are optional). To install these dependencies on ubuntu:
+dependencies are optional). To install these dependencies on Ubuntu:
 
 .. code:: shell
 

--- a/docs/source/dev_guide/how_to_test.rst
+++ b/docs/source/dev_guide/how_to_test.rst
@@ -233,8 +233,23 @@ An example generalized gradient test fixture is provided by
    :project: rascal
    :members:
 
-How to run the tests
---------------------
+Running the tests
+-----------------
 
-All tests are added as targets during  compilation by default. You can run all tests by executing ``ctest`` in the build folder. If the tests fail, you can re-run them verbosely using ``ctest -V`` to get a detailed account of which tests have failed.
+All tests are automatically compiled if ``BUILD_TESTS`` is set to ``ON`` with
+CMake. After building librascal, you can execute all tests by running ``ctest
+--output-on-failure`` in the build folder.
 
+Using Valgrind to check for memory errors
+-----------------------------------------
+
+`Valgrind <http://valgrind.org/>`_ is a collection of tools to instrument and
+analyse the execution of pre-compiled binaries. Here, we are interested in the
+``memcheck`` tool, that performs memory-related checks on the code: memory
+leaks, and invalid read and writes (i.e. buffer overrun). Valgrind works by
+intercepting calls to ``malloc``/``free`` (and thus ``new``/``delete``) to check
+that every ``malloc`` is followed by a ``free``.
+
+You can run librascal tests using Valgrind to check for memory errors by
+configuring cmake with ``RASCAL_TESTS_USE_VALGRIND=ON``. Then, running ``ctest``
+will execute all C++ tests with Valgrind.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,8 +18,11 @@ if (${RASCAL_TESTS_USE_VALGRIND})
         "--track-origins=yes"
         # use dsymutil to extract debug symbols on macOS
         "--dsymutil=yes"
-        # remove errors from the OS
+        # remove errors from the OS/external libraries
         "--suppressions=${CMAKE_CURRENT_SOURCE_DIR}/valgrind.suppressions"
+        # uncomment the line below if you wan to generate suppressions for new
+        # errors
+        # "--gen-suppressions=all"
     )
 
 else()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,31 @@
 find_package(Boost REQUIRED COMPONENTS unit_test_framework )
 
+option(RASCAL_TESTS_USE_VALGRIND "run all C++ tests within valgrind" OFF)
+
+if (${RASCAL_TESTS_USE_VALGRIND})
+    find_program(VALGRIND_EXECUTABLE "valgrind")
+    if ("${VALGRIND_EXECUTABLE}" STREQUAL "VALGRIND_EXECUTABLE-NOTFOUND")
+        message(FATAL_ERROR "Could not find valgrind")
+    endif()
+    set(TEST_RUNNER "${VALGRIND_EXECUTABLE}"
+        # fail the test if valgrind fails
+        "--error-exitcode=100"
+        # check for all kinds of leaks
+        "--leak-check=full"
+        "--show-leak-kinds=all"
+        "--errors-for-leak-kinds=all"
+        # track leaks origin to improve error messages
+        "--track-origins=yes"
+        # use dsymutil to extract debug symbols on macOS
+        "--dsymutil=yes"
+        # remove errors from the OS
+        "--suppressions=${CMAKE_CURRENT_SOURCE_DIR}/valgrind.suppressions"
+    )
+
+else()
+    set(TEST_RUNNER "")
+endif()
+
 add_library(rascal_tests_main STATIC helpers/tests_main.cc)
 target_compile_definitions(rascal_tests_main PUBLIC -DBOOST_TEST_DYN_LINK)
 target_link_libraries(rascal_tests_main ${Boost_LIBRARIES} "${LIBRASCAL_NAME}")
@@ -14,7 +40,7 @@ foreach(_file_ ${tests})
 
     add_test(
         NAME ${_name_}
-        COMMAND ${_name_} --report_level=detailed --build_info=TRUE
+        COMMAND ${TEST_RUNNER} $<TARGET_FILE:${_name_}> -- --report_level=detailed --build_info=TRUE
         # Run the tests in the root directory to give them access to the
         # reference data
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/tests/valgrind.suppressions
+++ b/tests/valgrind.suppressions
@@ -1,4 +1,13 @@
 {
+   Remove this when https://github.com/cosmo-epfl/librascal/issues/229 is fixed
+   Memcheck:Addr8
+   fun:_ZN6rascal13AdaptorFilterINS_22StructureManagerLammpsELm2EE11add_clusterILm2EEEvRKNS_16StructureManagerIS1_E10ClusterRefIXT_EEE
+   fun:_ZN6rascal19test_adaptor_filter13filter_2_testINS_13FilterFixtureINS_22StructureManagerLammpsELm2EEEE11test_methodEv
+   fun:_ZN6rascal19test_adaptor_filter21filter_2_test_invoker3runINS_13FilterFixtureINS_22StructureManagerLammpsELm2EEEEEvPN5boost4typeIT_EE
+}
+
+
+{
    boost unit test logger
    Memcheck:Leak
    ...

--- a/tests/valgrind.suppressions
+++ b/tests/valgrind.suppressions
@@ -1,0 +1,51 @@
+{
+   boost unit test logger
+   Memcheck:Leak
+   ...
+   fun:fwrite
+   ...
+   fun:_ZN5boost9unit_test15unit_test_log_t10test_startEm
+   ...
+}
+
+{
+   json lexer allocate through strtod_l
+   Memcheck:Leak
+   ...
+   fun:strtod_l
+   fun:_ZN8nlohmann6detail5lexerINS_10basic_jsonINSt3__13mapENS3_6vectorENS3_12basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEEbxydS9_NS_14adl_serializerEEEE11scan_numberEv
+   ...
+}
+
+{
+   Objc runtime
+   Memcheck:Leak
+   ...
+   fun:_objc_flush_caches
+   ...
+}
+
+{
+   Objc runtime
+   Memcheck:Leak
+   ...
+   fun:__objc_personality_v0
+   ...
+}
+
+{
+   macOS stuff
+   Memcheck:Leak
+   ...
+   fun:libSystem_initializer
+   ...
+}
+
+{
+   macOS stuff
+   Memcheck:Leak
+   fun:malloc
+   ...
+   fun:_ZN11ImageLoader19processInitializersERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   ...
+}


### PR DESCRIPTION
Fix #23

Some tests fail when using valgrind, which mean we can not currently run valgrind in CI. See #137, #205, #206.

- cpplint 'tests' also fail under valgrind, because they invoke `make` which leaks memory.
- python bindings test leak memory/use uninitialized variables inside Python interpreter

Also, related to #121, `test_calculators` takes 10 **minutes**!! to finish when running with valgrind.

We can still merge this, and enable valgrind in CI once everything above is fixed.

-----

- [X] Add tests, examples, and complete documentation of any added functionality
    - [X] Write additional documentation in the Sphinx (not docstrings!) to
          explain the feature and its usage in plain English