### PR TITLE
Fix compilation on OS X/clang

### DIFF
--- a/tests/test_adaptor.hh
+++ b/tests/test_adaptor.hh
@@ -373,9 +373,9 @@ namespace rascal {
                       {"initialization_arguments", {}}};
             json ad2{{"name", "AdaptorStrict"},
                      {"initialization_arguments", {{"cutoff", cutoff}}}};
-            adaptors.emplace_back(ad1);
+            adaptors.push_back(ad1);
             adaptors.push_back(ad1b);
-            adaptors.emplace_back(ad2);
+            adaptors.push_back(ad2);
 
             parameters["structure"] = structure;
             parameters["adaptors"] = adaptors;
@@ -414,7 +414,7 @@ namespace rascal {
         std::uniform_int_distribution<int> uni(1, n_atoms - 2);
         for (auto && cutoff : this->cutoffs) {
           for (auto && skin : this->skins) {
-            for (auto && consider_ghost_neighbours :
+            for (bool consider_ghost_neighbours :
                  this->consider_ghost_neighbours_list) {
               atomic_structure.set_structure(filename);
 
@@ -483,7 +483,7 @@ namespace rascal {
         std::uniform_int_distribution<int> uni(1, n_atoms - 2);
         for (auto && cutoff : this->cutoffs) {
           for (auto && skin : this->skins) {
-            for (auto && consider_ghost_neighbours :
+            for (bool consider_ghost_neighbours :
                  this->consider_ghost_neighbours_list) {
               atomic_structure.set_structure(filename);
               json parameters;


### PR DESCRIPTION
std::vector<bool> is a specialization of std::vector, using a single bit to store each bool. Indexing it/iterating over it do not yield `bool&`, but a wrapper type `std::vector<bool>::reference`, convertible to bool.

Since there is no `basic_json` constructor taking a `std::vector<bool>::reference`, compilation failed on macOS/clang (maybe related to libc++ vs libstdc++). 

A simple fix it to explicitly convert the values to bool.