### PR TITLE
Adapts get_dense_feature_matrix to new feature matrix getter

### DIFF
--- a/performance/profiles/profile_spherical_expansion.cc
+++ b/performance/profiles/profile_spherical_expansion.cc
@@ -137,7 +137,7 @@ int main(int argc, char * argv[]) {
 
   if (VERBOSE) {
     auto expn = manager->template get_property_ref<PropGrad_t>(
-                 representation.get_gradient_name()).get_dense_feature_matrix();
+                 representation.get_gradient_name()).get_features();
     std::cout << "Sample SphericalExpansion elements " << std::endl
               << expn(0, 0) << " " << expn(0, 1) << " " << expn(0, 2) << "\n"
               << expn(1, 0) << " " << expn(1, 1) << " " << expn(1, 2) << "\n"
@@ -164,7 +164,7 @@ int main(int argc, char * argv[]) {
   if (VERBOSE) {
     auto expn2 = manager->template get_property_ref<PropGrad_t>(
                  representation_gradients.get_gradient_name())
-                 .get_dense_feature_matrix();
+                 .get_features();
     std::cout << "Sample SphericalExpansion elements (should be identical) "
               << std::endl
               << expn2(0, 0) << " " << expn2(0, 1) << " " << expn2(0, 2) <<


### PR DESCRIPTION
Important pull request, master is not compiling currently, this fixes it.

What happened:
- feat/interpolator works I am about to merge just waiting for circleci
- feat/feature_matrix_getter gets merged
- feat/interpolator circleci says everything okay, git says it is mergeable without conflicts. I am not aware that master has changed and do the merge

So I merged without having a circleci check with the new master. When I merged, I got a complain from circleci because I have not adapted to the new feature matrix getter. This pull request fixes this.