### PR TITLE
Rebase onto master

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,14 +1,9 @@
+# Default style
+BasedOnStyle: LLVM
+# Customization
 AccessModifierOffset: -1
-SpacesBeforeTrailingComments: 2
-NamespaceIndentation: All
-SortIncludes: false
-PointerAlignment: Middle
 AlwaysBreakTemplateDeclarations: true
 ColumnLimit: 80
-KeepEmptyLinesAtTheStartOfBlocks: false
-IndentWidth: 2
-# rules related to include sorting
-SortIncludes: true
 IncludeBlocks: Regroup
 IncludeCategories:
   # rascal headers in "" with extension
@@ -26,3 +21,9 @@ IncludeCategories:
   # Headers in <> without extension, i.e. usually c/c++ standard library headers
   - Regex:           '<[[:alnum:]_]+>'
     Priority:        5
+IndentWidth: 2
+KeepEmptyLinesAtTheStartOfBlocks: false
+NamespaceIndentation: All
+PointerAlignment: Middle
+SortIncludes: true
+SpacesBeforeTrailingComments: 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,13 +218,13 @@ include(cpplint)
 # Checking hh/cc files for compliance with coding conventions
 if(CPPLINT_FOUND)
   # register the folders to check for cpp code conventions compliance
-  cpplint_add_subdirectory("${CMAKE_SOURCE_DIR}/src" "")
-  cpplint_add_subdirectory("${CMAKE_SOURCE_DIR}/tests" "")
   cpplint_add_subdirectory("${CMAKE_SOURCE_DIR}/bindings" "")
+  cpplint_add_subdirectory("${CMAKE_SOURCE_DIR}/examples"
+    "--filter=-build/namespaces")
   cpplint_add_subdirectory("${CMAKE_SOURCE_DIR}/performance/benchmarks" "")
   cpplint_add_subdirectory("${CMAKE_SOURCE_DIR}/performance/profiles" "")
-  cpplint_add_subdirectory("${CMAKE_SOURCE_DIR}/examples"
-  "--filter=-build/namespaces")
+  cpplint_add_subdirectory("${CMAKE_SOURCE_DIR}/src" "")
+  cpplint_add_subdirectory("${CMAKE_SOURCE_DIR}/tests" "")
 endif()
 
 # Check for clang-format
@@ -233,12 +233,12 @@ include(clangformat)
 if(CLANG_FORMAT_FOUND)
   # register the folders to apply clang-format with given configuration
   # .clang-format in project root folder
-  clang_format_add_subdirectory("${CMAKE_SOURCE_DIR}/src" "")
-  clang_format_add_subdirectory("${CMAKE_SOURCE_DIR}/tests" "")
   clang_format_add_subdirectory("${CMAKE_SOURCE_DIR}/bindings" "")
   clang_format_add_subdirectory("${CMAKE_SOURCE_DIR}/examples")
   clang_format_add_subdirectory("${CMAKE_SOURCE_DIR}/performance/benchmarks" "")
   clang_format_add_subdirectory("${CMAKE_SOURCE_DIR}/performance/profiles" "")
+  clang_format_add_subdirectory("${CMAKE_SOURCE_DIR}/src" "")
+  clang_format_add_subdirectory("${CMAKE_SOURCE_DIR}/tests" "")
 endif()
 
 # Check for autopep8
@@ -247,9 +247,9 @@ include(autopep8)
 if(AUTOPEP8_FOUND)
   # register the folders to apply autopep8 with given configuration
   # .pycodestyle in project root folder
-  autopep8_add_subdirectory("${CMAKE_SOURCE_DIR}/tests")
   autopep8_add_subdirectory("${CMAKE_SOURCE_DIR}/bindings")
   autopep8_add_subdirectory("${CMAKE_SOURCE_DIR}/scripts")
+  autopep8_add_subdirectory("${CMAKE_SOURCE_DIR}/tests")
 endif()
 
 # Removes every file in the build folder except the external libraries to


### PR DESCRIPTION
As per discussion yesterday, I checked `clang-format` versions 6, 7, 8, 9
With this updated configuration including a base-style it does not change anything for me, regardless of the `clang-format` version.

Please do check if that is also the case for whatever local configuration you have.

This PR should fix issue #217, i.e. commit noise due to clang-format
- Added base style
- Reordered alphabetically in .clang-format
- Reordered folders in `CMakeLists.txt` alphabetically

Tasks before review:
- [x] Merge with master and resolve any conflicts



Remaining tasks, out of scope of this pull request: (optional)
- I ask someone else with a different configuration to check for possible _noise_ and get back to me with the clang-format version
