### PR TITLE
Small python benchmarks fixes and improvements

### DIFF
--- a/performance/benchmarks/CMakeLists.txt
+++ b/performance/benchmarks/CMakeLists.txt
@@ -29,6 +29,5 @@ add_custom_target(
     COMMAND "PYTHONPATH=${CMAKE_BINARY_DIR}" ${PYTHON_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/benchmark_spherical_representations.py
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    DEPENDS ${ALL_BENCHMARKS}
-
+    DEPENDS ${ALL_BENCHMARKS} copy_python_bindings
 )

--- a/performance/benchmarks/CMakeLists.txt
+++ b/performance/benchmarks/CMakeLists.txt
@@ -6,25 +6,34 @@ mark_as_advanced(RUN_BENCHMARKS_FLAGS)
 file(GLOB benchmarks "${CMAKE_SOURCE_DIR}/performance/benchmarks/*.cc")
 list(APPEND benchmarks "${CMAKE_SOURCE_DIR}/docs/source/tutorials/benchmark_tutorial.cc")
 
-set(ALL_BENCHMARKS "")
+set(ALL_CXX_BENCHMARKS "")
 foreach(benchmark ${benchmarks})
   get_filename_component(name  ${benchmark} NAME_WE)
   add_executable(${name} ${benchmark})
   target_link_libraries(${name} "${LIBRASCAL_NAME}")
   target_link_libraries(${name} Threads::Threads)
   target_link_libraries(${name} benchmark)
-  list(APPEND ALL_BENCHMARKS ${name})
+  list(APPEND ALL_CXX_BENCHMARKS ${name})
 endforeach()
 
-# one target to execute all benchmarks with the user flags
-add_custom_target(
-    benchmarks
-    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/benchmark_interpolator
-            --benchmark_counters_tabular=true
-            ${RUN_BENCHMARKS_FLAGS}
-    # Assume bash-like shell to pass PYTHONPATH
-    COMMAND "PYTHONPATH=${CMAKE_BINARY_DIR}" ${PYTHON_EXECUTABLE}
-            ${CMAKE_CURRENT_SOURCE_DIR}/benchmark_spherical_representations.py
+set(CXX_BENCH_FLAGS "--benchmark_counters_tabular=true" ${RUN_BENCHMARKS_FLAGS})
+
+add_custom_target(cpp_benchmarks
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/benchmark_interpolator ${CXX_BENCH_FLAGS}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    DEPENDS ${ALL_BENCHMARKS} copy_python_bindings
+    DEPENDS ${ALL_CXX_BENCHMARKS}
 )
+
+add_custom_target(benchmarks DEPENDS cpp_benchmarks)
+
+if (BUILD_BINDINGS)
+    add_custom_target(python_benchmarks
+        # Assume bash-like shell to pass PYTHONPATH
+        COMMAND "PYTHONPATH=${CMAKE_BINARY_DIR}" ${PYTHON_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/benchmark_spherical_representations.py
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        DEPENDS copy_python_bindings
+    )
+
+    add_dependencies(benchmarks python_benchmarks)
+endif()

--- a/performance/benchmarks/CMakeLists.txt
+++ b/performance/benchmarks/CMakeLists.txt
@@ -14,9 +14,6 @@ foreach(benchmark ${benchmarks})
   target_link_libraries(${name} Threads::Threads)
   target_link_libraries(${name} benchmark)
   list(APPEND ALL_BENCHMARKS ${name})
-
-  # surpresses the "'CSVReporter' is deprecated" errors when compiling benchmark.cc
-  set_target_properties(${name} PROPERTIES COMPILE_OPTIONS "-Wno-deprecated-declarations" )
 endforeach()
 
 # one target to execute all benchmarks with the user flags

--- a/performance/benchmarks/benchmark_spherical_representations.py
+++ b/performance/benchmarks/benchmark_spherical_representations.py
@@ -61,7 +61,7 @@ optimizations_args = [
 radial_bases = ['GTO', 'DVR']
 
 
-@benchmarks.timer
+@benchmarks.bench
 def transform_representation(representation, frames, **kwargs):
     representation.transform(frames)
 

--- a/performance/benchmarks/benchmarks.py
+++ b/performance/benchmarks/benchmarks.py
@@ -24,24 +24,25 @@
 # Boston, MA 02111-1307, USA.
 
 import functools
-import time
+from timeit import default_timer as timer
 
-# Global parameters for benchmark
-nb_iterations = 5
+DEFAULT_ITERATIONS = 100
 
 
-def timer(func):
+def bench(func):
     """Print the runtime of the decorated function"""
     @functools.wraps(func)
     def wrapper_timer(*args, **kwargs):
-        nb_iterations = kwargs['nb_iterations']
-        times = nb_iterations * [0]
+        nb_iterations = kwargs.get('nb_iterations', DEFAULT_ITERATIONS)
+
+        total_time = 0.0
         for i in range(nb_iterations):
-            start_time = time.perf_counter()
+            start_time = timer()
             value = func(*args, **kwargs)
-            end_time = time.perf_counter()
-            times[i] = end_time - start_time
-        run_time = sum(times) / len(times)
-        print(f"Finished in {run_time:.6f} secs is mean time for {nb_iterations} runs")
+            end_time = timer()
+            total_time += end_time - start_time
+
+        total_time /= nb_iterations
+        print(f"Finished in {total_time*1e6:.2f} ns over {nb_iterations} runs")
         return value
     return wrapper_timer


### PR DESCRIPTION
Fix dependencies and use `timeit.default_timer` to select the most precise clock.