### PR TITLE
Fix invalid read in hyp1f1 tests

### DIFF
--- a/tests/test_calculator.cc
+++ b/tests/test_calculator.cc
@@ -438,7 +438,6 @@ namespace rascal {
                                                 typename Fix::Manager_t>
             grad_fix("reference_data/spherical_expansion_gradient_test.json",
                      manager, provider);
-        grad_fix.verbosity = GradientTestFixture::VerbosityValue::DEBUG;
         /* ---- grad-test-example-end1 ---- */
         if (grad_fix.verbosity >= GradientTestFixture::VerbosityValue::INFO) {
           std::cout << "Testing structure: " << *filename_it << std::endl;

--- a/tests/test_math.hh
+++ b/tests/test_math.hh
@@ -471,6 +471,9 @@ namespace rascal {
   };
 
   struct Hyp1f1GradientProvider {
+
+    static const size_t n_arguments = 1;
+
     Hyp1f1GradientProvider(size_t max_radial, size_t max_angular, double fac_a,
                            Eigen::Ref<Eigen::VectorXd> fac_b)
         : max_radial{max_radial}, max_angular{max_angular}, fac_a{fac_a} {

--- a/tests/test_math.hh
+++ b/tests/test_math.hh
@@ -484,7 +484,7 @@ namespace rascal {
 
     ~Hyp1f1GradientProvider() = default;
 
-    Eigen::Ref<Eigen::Array<double, 1, Eigen::Dynamic>>
+    Eigen::Array<double, 1, Eigen::Dynamic>
     f(const Eigen::Matrix<double, 1, 1> & input_v) {
       this->hyp1f1_calculator.calc(input_v(0), this->fac_a, this->fac_b);
       Eigen::MatrixXd result(this->max_radial, this->max_angular + 1);
@@ -494,7 +494,7 @@ namespace rascal {
       return result_flat;
     }
 
-    Eigen::Ref<Eigen::Array<double, 1, Eigen::Dynamic>>
+    Eigen::Array<double, 1, Eigen::Dynamic>
     grad_f(const Eigen::Matrix<double, 1, 1> & input_v) {
       this->hyp1f1_calculator.calc(input_v(0), this->fac_a, this->fac_b, true);
       Eigen::MatrixXd result(this->max_radial, this->max_angular + 1);

--- a/tests/test_math.hh
+++ b/tests/test_math.hh
@@ -471,7 +471,6 @@ namespace rascal {
   };
 
   struct Hyp1f1GradientProvider {
-
     static const size_t n_arguments = 1;
 
     Hyp1f1GradientProvider(size_t max_radial, size_t max_angular, double fac_a,


### PR DESCRIPTION
Fix #137 

The problem was that the `Hyp1f1GradientProvider` was returning `Eigen::Ref`s to arrays it didn't actually have persistent storage for. While it worked, it can certainly be considered quite dodgy, so it's right that `valgrind` picked it up.

Tasks before review:

- [x] Add tests, examples, and complete documentation of any added functionality
    - [x] For bugfix pull requests, list here which tests have been added or re-enabled
          to verify the fix and catch future regressions as well as similar bugs
          elsewhere in the code.
        - When the `valgrind` tests are enabled by default (as discussed in #207), this will no longer be an issue.
- [x] Run `make lint` on the project, ensure it passes
    - [x] Run `make pretty-cpp` and `make pretty-python`, check that the
          auto-formatting is sensible
- [x] Merge with master and resolve any conflicts
