### PR TITLE
Bugfig/invalid read adaptor filter

### DIFF
--- a/src/rascal/structure_managers/adaptor_filter.hh
+++ b/src/rascal/structure_managers/adaptor_filter.hh
@@ -406,15 +406,10 @@ namespace rascal {
     if (indices_container.size() == 0) {
       return false;
     }
+
     auto && last_cluster_index{indices_container.back()(Layer)};
 
-    std::cout << "size of container " << indices_container.size() << std::endl;
-
-    std::cout << "AdFi: last_cluster_index " << last_cluster_index << std::endl;
-    std::cout << "AdFi: cluster index " << cluster.get_cluster_index(Layer)
-              << std::endl;
-    bool has_cl{last_cluster_index == cluster.get_cluster_index(Layer)};
-    return has_cl;
+    return last_cluster_index == cluster.get_cluster_index(Layer);
   }
 
   /* ---------------------------------------------------------------------- */

--- a/src/rascal/structure_managers/adaptor_filter.hh
+++ b/src/rascal/structure_managers/adaptor_filter.hh
@@ -408,7 +408,13 @@ namespace rascal {
     }
     auto && last_cluster_index{indices_container.back()(Layer)};
 
-    return last_cluster_index == cluster.get_cluster_index(Layer);
+    std::cout << "size of container " << indices_container.size() << std::endl;
+
+    std::cout << "AdFi: last_cluster_index " << last_cluster_index << std::endl;
+    std::cout << "AdFi: cluster index " << cluster.get_cluster_index(Layer)
+              << std::endl;
+    bool has_cl{last_cluster_index == cluster.get_cluster_index(Layer)};
+    return has_cl;
   }
 
   /* ---------------------------------------------------------------------- */

--- a/src/rascal/structure_managers/property_typed.hh
+++ b/src/rascal/structure_managers/property_typed.hh
@@ -319,7 +319,11 @@ namespace rascal {
      * Accessor for last pushed entry for dynamically sized properties
      */
     reference back() {
-      auto && index{this->values.size() - this->get_nb_comp()};
+      // -1 is correction for 0-start indexing
+      auto && index{this->values.size() / this->get_nb_comp() - 1};
+      if (index < 0) {
+        throw std::runtime_error("Property is empty, .back() is undefined.");
+      }
       return Value_t::get_ref(this->values[index * this->get_nb_comp()],
                               this->get_nb_row(), this->get_nb_col());
     }

--- a/src/rascal/structure_managers/property_typed.hh
+++ b/src/rascal/structure_managers/property_typed.hh
@@ -320,10 +320,10 @@ namespace rascal {
      */
     reference back() {
       // -1 is correction for 0-start indexing
-      auto && index{this->values.size() / this->get_nb_comp() - 1};
-      if (index < 0) {
+      if (this->values.size() == 0) {
         throw std::runtime_error("Property is empty, .back() is undefined.");
       }
+      auto && index{this->values.size() / this->get_nb_comp() - 1};
       return Value_t::get_ref(this->values[index * this->get_nb_comp()],
                               this->get_nb_row(), this->get_nb_col());
     }

--- a/src/rascal/structure_managers/property_typed.hh
+++ b/src/rascal/structure_managers/property_typed.hh
@@ -319,10 +319,10 @@ namespace rascal {
      * Accessor for last pushed entry for dynamically sized properties
      */
     reference back() {
-      // -1 is correction for 0-start indexing
       if (this->values.size() == 0) {
         throw std::runtime_error("Property is empty, .back() is undefined.");
       }
+      // -1 is correction for 0-start indexing
       auto && index{this->values.size() / this->get_nb_comp() - 1};
       return Value_t::get_ref(this->values[index * this->get_nb_comp()],
                               this->get_nb_row(), this->get_nb_col());

--- a/tests/test_adaptor_filter.cc
+++ b/tests/test_adaptor_filter.cc
@@ -83,6 +83,7 @@ namespace rascal {
 
     for (auto atom : Fix::fixture.manager) {
       const bool include(dist(rd));
+      std::cout << "f1 include? = " << include << std::endl;
       if (include) {
         Fix::manager.add_cluster(atom);
         atom_tag_list.push_back(atom.get_atom_tag());
@@ -127,7 +128,9 @@ namespace rascal {
                 << Fix::fixture.manager->get_nb_clusters(2);
       std::cout << " starts now." << std::endl;
     }
-    std::random_device rd{};
+    //    std::random_device rd{};
+    // predictably random
+    std::mt19937 rd{};
     std::uniform_int_distribution<int> dist(0, 1);
     std::vector<std::array<int, 2>> atom_tag_list{};
 
@@ -150,6 +153,7 @@ namespace rascal {
           std::cout << std::endl;
         }
         const bool include(dist(rd));
+        std::cout << "f2 include? = " << include << std::endl;
         if (include) {
           Fix::manager.add_cluster(pair);
           atom_tag_list.push_back(pair.get_atom_tag_list());

--- a/tests/test_adaptor_filter.cc
+++ b/tests/test_adaptor_filter.cc
@@ -83,7 +83,6 @@ namespace rascal {
 
     for (auto atom : Fix::fixture.manager) {
       const bool include(dist(rd));
-      std::cout << "f1 include? = " << include << std::endl;
       if (include) {
         Fix::manager.add_cluster(atom);
         atom_tag_list.push_back(atom.get_atom_tag());
@@ -128,9 +127,9 @@ namespace rascal {
                 << Fix::fixture.manager->get_nb_clusters(2);
       std::cout << " starts now." << std::endl;
     }
-    //    std::random_device rd{};
-    // predictably random
-    std::mt19937 rd{};
+    std::random_device rd{};
+    // use the following generator comment in for predictabe randomness
+    // std::mt19937 rd{};
     std::uniform_int_distribution<int> dist(0, 1);
     std::vector<std::array<int, 2>> atom_tag_list{};
 
@@ -153,7 +152,6 @@ namespace rascal {
           std::cout << std::endl;
         }
         const bool include(dist(rd));
-        std::cout << "f2 include? = " << include << std::endl;
         if (include) {
           Fix::manager.add_cluster(pair);
           atom_tag_list.push_back(pair.get_atom_tag_list());

--- a/tests/test_properties.cc
+++ b/tests/test_properties.cc
@@ -55,6 +55,7 @@ namespace rascal {
     }
   }
 
+  /* ---------------------------------------------------------------------- */
   BOOST_FIXTURE_TEST_CASE_TEMPLATE(atom_constructor_tests, Fix,
                                    atom_vector_property_fixtures, Fix) {
     bool verbose{false};
@@ -88,6 +89,18 @@ namespace rascal {
     }
   }
 
+  /* ---------------------------------------------------------------------- */
+  /**
+   * Checks for the throw of the runtime error in member .back() of
+   * `PropertyTyped`.
+   */
+  BOOST_FIXTURE_TEST_CASE(
+      property_typed_runtime_error,
+      AtomPropertyFixture<StructureManagerCentersStackFixture>) {
+    BOOST_CHECK_THROW(atom_dynamic_vector_property.back(), std::runtime_error);
+  }
+
+  /* ---------------------------------------------------------------------- */
   BOOST_FIXTURE_TEST_CASE(
       fill_atom_vector_property_order_one_test,
       AtomPropertyFixture<StructureManagerCentersStackFixture>) {
@@ -103,6 +116,7 @@ namespace rascal {
 
     atom_vector_property.resize();
     atom_dynamic_vector_property.resize();
+
     if (verbose) {
       std::cout << ">> atom_vector_property size ";
       std::cout << atom_vector_property.size();

--- a/tests/valgrind.suppressions
+++ b/tests/valgrind.suppressions
@@ -1,13 +1,4 @@
 {
-   Remove this when https://github.com/cosmo-epfl/librascal/issues/229 is fixed
-   Memcheck:Addr8
-   fun:_ZN6rascal13AdaptorFilterINS_22StructureManagerLammpsELm2EE11add_clusterILm2EEEvRKNS_16StructureManagerIS1_E10ClusterRefIXT_EEE
-   fun:_ZN6rascal19test_adaptor_filter13filter_2_testINS_13FilterFixtureINS_22StructureManagerLammpsELm2EEEE11test_methodEv
-   fun:_ZN6rascal19test_adaptor_filter21filter_2_test_invoker3runINS_13FilterFixtureINS_22StructureManagerLammpsELm2EEEEEvPN5boost4typeIT_EE
-}
-
-
-{
    boost unit test logger
    Memcheck:Leak
    ...


### PR DESCRIPTION
(Describe your pull request in 1-2 sentences)

Fix #229

Error was in the access for the `.back()` operator in `PropertyTyped`. The index calculation was not accounting for the _start at zero_.

I also removed the suppressions and left a comment in the test where the `random_device` is chosen to be able to quickly switch to predictable behaviour in the future.