### PR TITLE
Added CommentReflow option to clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -25,5 +25,6 @@ IndentWidth: 2
 KeepEmptyLinesAtTheStartOfBlocks: false
 NamespaceIndentation: All
 PointerAlignment: Middle
+ReflowComments: true
 SortIncludes: true
 SpacesBeforeTrailingComments: 2

--- a/src/rascal/structure_managers/structure_manager.hh
+++ b/src/rascal/structure_managers/structure_manager.hh
@@ -899,8 +899,7 @@ namespace rascal {
     };
   }  // namespace internal
 
-  /* ----------------------------------------------------------------------
-   */
+  /* ---------------------------------------------------------------------- */
   /**
    * Definition of the ``AtomRef`` class. It is the return type when
    * iterating over the first order of a manager.
@@ -956,8 +955,7 @@ namespace rascal {
     int index;
   };
 
-  /* ----------------------------------------------------------------------
-   */
+  /* ---------------------------------------------------------------------- */
   /**
    * Class definitionobject when iterating over the manager, then atoms,
    * then pairs, etc. in deeper Orders. This object itself is iterable again
@@ -1287,8 +1285,7 @@ namespace rascal {
                                                           this->get_manager());
   }
 
-  /* ----------------------------------------------------------------------
-   */
+  /* ---------------------------------------------------------------- */
   /**
    * Helper functions to avoid needing dereferencing a manager in a
    * shared_ptr to loop over the centers.
@@ -1303,8 +1300,7 @@ namespace rascal {
     return ptr->end();
   }
 
-  /* ----------------------------------------------------------------------
-   */
+  /* ---------------------------------------------------------------- */
   /**
    * Class definition of the iterator. This is used by all clusters. It is
    * specialized for the case Order=1, when iterating over a manager and the
@@ -1504,8 +1500,7 @@ namespace rascal {
     const size_t offset;
   };
 
-  /* ----------------------------------------------------------------------
-   */
+  /* --------------------------------------------------------------------- */
   /**
    * A class which provides the iteration range from start to the end of the
    * atoms including additional ghost atoms.
@@ -1552,8 +1547,6 @@ namespace rascal {
    private:
   };
 
-  /* ----------------------------------------------------------------------
-   */
   /**
    * A class which provides the iteration range from for all ghost atoms in
    * the structure. If no ghost atoms exist, the iterator is of size zero.


### PR DESCRIPTION
Comments in the code are sometimes changed, when people doing manual vs automatic comment reflowing.

`clang-format` has the option to automatically reflow the comments. I added that option, so comments are reflowed by clang. 
Fixes #248 and should lead to less commit noise in the future regarding comments.

Hint: If you _want_ a line break at a specific point, you need to add an empty line. This is nothing new and has been observed throughout our code already. Just putting it here as a reminder.