### PR TITLE
Maintenance/move util files

### DIFF
--- a/bindings/bind_include.hh
+++ b/bindings/bind_include.hh
@@ -29,7 +29,7 @@
 #define BINDINGS_BIND_INCLUDE_HH_
 
 #include "rascal/atomic_structure.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <pybind11/eigen.h>
 #include <pybind11/iostream.h>

--- a/bindings/bind_include.hh
+++ b/bindings/bind_include.hh
@@ -28,7 +28,7 @@
 #ifndef BINDINGS_BIND_INCLUDE_HH_
 #define BINDINGS_BIND_INCLUDE_HH_
 
-#include "rascal/atomic_structure.hh"
+#include "rascal/structure_managers/atomic_structure.hh"
 #include "rascal/utils/utils.hh"
 
 #include <pybind11/eigen.h>

--- a/examples/json_structure.cc
+++ b/examples/json_structure.cc
@@ -27,7 +27,6 @@
  */
 
 #include "rascal/basic_types.hh"
-#include "rascal/json_io.hh"
 #include "rascal/representations/calculator_sorted_coulomb.hh"
 #include "rascal/representations/calculator_spherical_expansion.hh"
 #include "rascal/representations/calculator_spherical_invariants.hh"
@@ -35,6 +34,7 @@
 #include "rascal/structure_managers/adaptor_strict.hh"
 #include "rascal/structure_managers/make_structure_manager.hh"
 #include "rascal/structure_managers/structure_manager_centers.hh"
+#include "rascal/utils/json_io.hh"
 #include "rascal/utils/utils.hh"
 
 #include <cmath>

--- a/examples/json_structure.cc
+++ b/examples/json_structure.cc
@@ -26,7 +26,6 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#include "rascal/basic_types.hh"
 #include "rascal/representations/calculator_sorted_coulomb.hh"
 #include "rascal/representations/calculator_spherical_expansion.hh"
 #include "rascal/representations/calculator_spherical_invariants.hh"
@@ -34,6 +33,7 @@
 #include "rascal/structure_managers/adaptor_strict.hh"
 #include "rascal/structure_managers/make_structure_manager.hh"
 #include "rascal/structure_managers/structure_manager_centers.hh"
+#include "rascal/utils/basic_types.hh"
 #include "rascal/utils/json_io.hh"
 #include "rascal/utils/utils.hh"
 

--- a/examples/json_structure.cc
+++ b/examples/json_structure.cc
@@ -35,7 +35,7 @@
 #include "rascal/structure_managers/adaptor_strict.hh"
 #include "rascal/structure_managers/make_structure_manager.hh"
 #include "rascal/structure_managers/structure_manager_centers.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <cmath>
 #include <functional>

--- a/examples/spherical_expansion_example.cc
+++ b/examples/spherical_expansion_example.cc
@@ -25,16 +25,16 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#include "rascal/atomic_structure.hh"
-#include "rascal/basic_types.hh"
 #include "rascal/representations/calculator_sorted_coulomb.hh"
 #include "rascal/representations/calculator_spherical_expansion.hh"
 #include "rascal/representations/calculator_spherical_invariants.hh"
 #include "rascal/structure_managers/adaptor_center_contribution.hh"
 #include "rascal/structure_managers/adaptor_neighbour_list.hh"
 #include "rascal/structure_managers/adaptor_strict.hh"
+#include "rascal/structure_managers/atomic_structure.hh"
 #include "rascal/structure_managers/make_structure_manager.hh"
 #include "rascal/structure_managers/structure_manager_centers.hh"
+#include "rascal/utils/basic_types.hh"
 #include "rascal/utils/utils.hh"
 
 #include <chrono>

--- a/examples/spherical_expansion_example.cc
+++ b/examples/spherical_expansion_example.cc
@@ -35,7 +35,7 @@
 #include "rascal/structure_managers/adaptor_strict.hh"
 #include "rascal/structure_managers/make_structure_manager.hh"
 #include "rascal/structure_managers/structure_manager_centers.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <chrono>
 #include <cmath>

--- a/examples/spherical_invariants_example.cc
+++ b/examples/spherical_invariants_example.cc
@@ -25,16 +25,16 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#include "rascal/atomic_structure.hh"
-#include "rascal/basic_types.hh"
 #include "rascal/representations/calculator_sorted_coulomb.hh"
 #include "rascal/representations/calculator_spherical_expansion.hh"
 #include "rascal/representations/calculator_spherical_invariants.hh"
 #include "rascal/structure_managers/adaptor_center_contribution.hh"
 #include "rascal/structure_managers/adaptor_neighbour_list.hh"
 #include "rascal/structure_managers/adaptor_strict.hh"
+#include "rascal/structure_managers/atomic_structure.hh"
 #include "rascal/structure_managers/make_structure_manager.hh"
 #include "rascal/structure_managers/structure_manager_centers.hh"
+#include "rascal/utils/basic_types.hh"
 #include "rascal/utils/utils.hh"
 
 #include <chrono>

--- a/examples/spherical_invariants_example.cc
+++ b/examples/spherical_invariants_example.cc
@@ -35,7 +35,7 @@
 #include "rascal/structure_managers/adaptor_strict.hh"
 #include "rascal/structure_managers/make_structure_manager.hh"
 #include "rascal/structure_managers/structure_manager_centers.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <chrono>
 #include <cmath>

--- a/performance/benchmarks/benchmark_interpolator.hh
+++ b/performance/benchmarks/benchmark_interpolator.hh
@@ -30,7 +30,6 @@
 
 #include "benchmarks.hh"
 
-#include "rascal/json_io.hh"
 #include "rascal/math/interpolator.hh"
 #include "rascal/representations/calculator_spherical_expansion.hh"
 #include "rascal/representations/calculator_spherical_invariants.hh"
@@ -39,6 +38,7 @@
 #include "rascal/structure_managers/adaptor_strict.hh"
 #include "rascal/structure_managers/make_structure_manager.hh"
 #include "rascal/structure_managers/structure_manager_centers.hh"
+#include "rascal/utils/json_io.hh"
 
 #include <functional>
 #include <iostream>

--- a/performance/benchmarks/benchmarks.hh
+++ b/performance/benchmarks/benchmarks.hh
@@ -29,7 +29,7 @@
 #ifndef PERFORMANCE_BENCHMARKS_BENCHMARKS_HH_
 #define PERFORMANCE_BENCHMARKS_BENCHMARKS_HH_
 
-#include "rascal/json_io.hh"
+#include "rascal/utils/json_io.hh"
 
 #include <benchmark/benchmark.h>
 #include <sys/stat.h>

--- a/performance/profiles/profile_matrix_cubic_spline.cc
+++ b/performance/profiles/profile_matrix_cubic_spline.cc
@@ -30,9 +30,9 @@
 
 #include "utils.hh"
 
-#include "rascal/json_io.hh"
 #include "rascal/math/interpolator.hh"
 #include "rascal/representations/calculator_spherical_expansion.hh"
+#include "rascal/utils/json_io.hh"
 
 #include <chrono>
 

--- a/performance/profiles/profile_scalar_cubic_spline.cc
+++ b/performance/profiles/profile_scalar_cubic_spline.cc
@@ -30,9 +30,9 @@
 
 #include "utils.hh"
 
-#include "rascal/json_io.hh"
 #include "rascal/math/hyp1f1.hh"
 #include "rascal/math/interpolator.hh"
+#include "rascal/utils/json_io.hh"
 
 #include <chrono>
 #include <iostream>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,7 @@
 
 set(RASCAL_SOURCES
     rascal/json_io.cc
-    rascal/units.cc
+    rascal/utils/units.cc
     rascal/utils/utils.cc
     rascal/utils/sparsify_fps.cc
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,7 @@
 set(RASCAL_SOURCES
     rascal/json_io.cc
     rascal/units.cc
-    rascal/utils.cc
+    rascal/utils/utils.cc
     rascal/utils/sparsify_fps.cc
 
     rascal/math/bessel.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,7 @@
 # =============================================================================
 
 set(RASCAL_SOURCES
-    rascal/json_io.cc
+    rascal/utils/json_io.cc
     rascal/utils/units.cc
     rascal/utils/utils.cc
     rascal/utils/sparsify_fps.cc

--- a/src/rascal/atomic_structure.hh
+++ b/src/rascal/atomic_structure.hh
@@ -31,8 +31,8 @@
 #define SRC_RASCAL_ATOMIC_STRUCTURE_HH_
 
 #include "rascal/basic_types.hh"
-#include "rascal/json_io.hh"
 #include "rascal/math/utils.hh"
+#include "rascal/utils/json_io.hh"
 
 #include <Eigen/Dense>
 

--- a/src/rascal/json_io.hh
+++ b/src/rascal/json_io.hh
@@ -34,7 +34,7 @@
  * documentation.
  */
 #include "rascal/external/json.hpp"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <Eigen/Dense>
 

--- a/src/rascal/models/kernels.hh
+++ b/src/rascal/models/kernels.hh
@@ -28,9 +28,9 @@
 #ifndef SRC_RASCAL_MODELS_KERNELS_HH_
 #define SRC_RASCAL_MODELS_KERNELS_HH_
 
-#include "rascal/json_io.hh"
 #include "rascal/math/utils.hh"
 #include "rascal/structure_managers/structure_manager_collection.hh"
+#include "rascal/utils/json_io.hh"
 
 namespace rascal {
 

--- a/src/rascal/representations/calculator_base.hh
+++ b/src/rascal/representations/calculator_base.hh
@@ -28,9 +28,9 @@
 #ifndef SRC_RASCAL_REPRESENTATIONS_CALCULATOR_BASE_HH_
 #define SRC_RASCAL_REPRESENTATIONS_CALCULATOR_BASE_HH_
 
-#include "rascal/json_io.hh"
 #include "rascal/structure_managers/property_block_sparse.hh"
 #include "rascal/structure_managers/structure_manager_base.hh"
+#include "rascal/utils/json_io.hh"
 
 #include <Eigen/Dense>
 

--- a/src/rascal/representations/calculator_sorted_coulomb.hh
+++ b/src/rascal/representations/calculator_sorted_coulomb.hh
@@ -31,7 +31,7 @@
 #include "rascal/representations/calculator_base.hh"
 #include "rascal/structure_managers/property.hh"
 #include "rascal/structure_managers/structure_manager.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <math.h>
 

--- a/src/rascal/representations/calculator_spherical_covariants.hh
+++ b/src/rascal/representations/calculator_spherical_covariants.hh
@@ -38,7 +38,7 @@
 #include "rascal/structure_managers/property.hh"
 #include "rascal/structure_managers/property_block_sparse.hh"
 #include "rascal/structure_managers/structure_manager.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <Eigen/Dense>
 #include <Eigen/Eigenvalues>

--- a/src/rascal/representations/calculator_spherical_expansion.hh
+++ b/src/rascal/representations/calculator_spherical_expansion.hh
@@ -41,7 +41,7 @@
 #include "rascal/representations/cutoff_functions.hh"
 #include "rascal/structure_managers/property_block_sparse.hh"
 #include "rascal/structure_managers/structure_manager.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <Eigen/Dense>
 #include <Eigen/Eigenvalues>

--- a/src/rascal/representations/calculator_spherical_invariants.hh
+++ b/src/rascal/representations/calculator_spherical_invariants.hh
@@ -36,7 +36,7 @@
 #include "rascal/representations/calculator_spherical_expansion.hh"
 #include "rascal/structure_managers/property_block_sparse.hh"
 #include "rascal/structure_managers/structure_manager.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <wigxjpf.h>
 

--- a/src/rascal/representations/cutoff_functions.hh
+++ b/src/rascal/representations/cutoff_functions.hh
@@ -31,7 +31,7 @@
 
 #include "rascal/math/utils.hh"
 #include "rascal/representations/calculator_base.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <Eigen/Dense>
 

--- a/src/rascal/structure_managers/adaptor_center_contribution.hh
+++ b/src/rascal/structure_managers/adaptor_center_contribution.hh
@@ -32,7 +32,7 @@
 #include "rascal/structure_managers/property.hh"
 #include "rascal/structure_managers/structure_manager.hh"
 #include "rascal/structure_managers/updateable_base.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 namespace rascal {
   /*

--- a/src/rascal/structure_managers/adaptor_filter.hh
+++ b/src/rascal/structure_managers/adaptor_filter.hh
@@ -33,7 +33,7 @@
 #include "rascal/structure_managers/cluster_ref_key.hh"
 #include "rascal/structure_managers/filter_base.hh"
 #include "rascal/structure_managers/structure_manager.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <type_traits>
 

--- a/src/rascal/structure_managers/adaptor_full_neighbour_list.hh
+++ b/src/rascal/structure_managers/adaptor_full_neighbour_list.hh
@@ -32,7 +32,7 @@
 
 #include "rascal/structure_managers/property.hh"
 #include "rascal/structure_managers/structure_manager.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 namespace rascal {
   /**

--- a/src/rascal/structure_managers/adaptor_half_neighbour_list.hh
+++ b/src/rascal/structure_managers/adaptor_half_neighbour_list.hh
@@ -32,7 +32,7 @@
 
 #include "rascal/structure_managers/property.hh"
 #include "rascal/structure_managers/structure_manager.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 namespace rascal {
   /**

--- a/src/rascal/structure_managers/adaptor_increase_maxorder.hh
+++ b/src/rascal/structure_managers/adaptor_increase_maxorder.hh
@@ -34,7 +34,7 @@
 #include "rascal/lattice.hh"
 #include "rascal/structure_managers/property.hh"
 #include "rascal/structure_managers/structure_manager.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <algorithm>
 #include <set>

--- a/src/rascal/structure_managers/adaptor_increase_maxorder.hh
+++ b/src/rascal/structure_managers/adaptor_increase_maxorder.hh
@@ -30,10 +30,10 @@
 #ifndef SRC_RASCAL_STRUCTURE_MANAGERS_ADAPTOR_INCREASE_MAXORDER_HH_
 #define SRC_RASCAL_STRUCTURE_MANAGERS_ADAPTOR_INCREASE_MAXORDER_HH_
 
-#include "rascal/basic_types.hh"
-#include "rascal/lattice.hh"
+#include "rascal/structure_managers/lattice.hh"
 #include "rascal/structure_managers/property.hh"
 #include "rascal/structure_managers/structure_manager.hh"
+#include "rascal/utils/basic_types.hh"
 #include "rascal/utils/utils.hh"
 
 #include <algorithm>

--- a/src/rascal/structure_managers/adaptor_neighbour_list.hh
+++ b/src/rascal/structure_managers/adaptor_neighbour_list.hh
@@ -37,7 +37,7 @@
 #include "rascal/lattice.hh"
 #include "rascal/structure_managers/property.hh"
 #include "rascal/structure_managers/structure_manager.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <set>
 #include <vector>

--- a/src/rascal/structure_managers/adaptor_neighbour_list.hh
+++ b/src/rascal/structure_managers/adaptor_neighbour_list.hh
@@ -32,11 +32,11 @@
 #ifndef SRC_RASCAL_STRUCTURE_MANAGERS_ADAPTOR_NEIGHBOUR_LIST_HH_
 #define SRC_RASCAL_STRUCTURE_MANAGERS_ADAPTOR_NEIGHBOUR_LIST_HH_
 
-#include "rascal/atomic_structure.hh"
-#include "rascal/basic_types.hh"
-#include "rascal/lattice.hh"
+#include "rascal/structure_managers/atomic_structure.hh"
+#include "rascal/structure_managers/lattice.hh"
 #include "rascal/structure_managers/property.hh"
 #include "rascal/structure_managers/structure_manager.hh"
+#include "rascal/utils/basic_types.hh"
 #include "rascal/utils/utils.hh"
 
 #include <set>

--- a/src/rascal/structure_managers/adaptor_strict.hh
+++ b/src/rascal/structure_managers/adaptor_strict.hh
@@ -34,7 +34,7 @@
 #include "rascal/structure_managers/property.hh"
 #include "rascal/structure_managers/structure_manager.hh"
 #include "rascal/structure_managers/updateable_base.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 namespace rascal {
   /*

--- a/src/rascal/structure_managers/atomic_structure.hh
+++ b/src/rascal/structure_managers/atomic_structure.hh
@@ -1,5 +1,5 @@
 /**
- * @file   rascal/atomic_structure.hh
+ * @file   rascal/structure_managers/atomic_structure.hh
  *
  * @author  Felix Musil <felix.musil@epfl.ch>
  * @author  Markus Stricker <markus.stricker@epfl.ch>
@@ -27,11 +27,11 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#ifndef SRC_RASCAL_ATOMIC_STRUCTURE_HH_
-#define SRC_RASCAL_ATOMIC_STRUCTURE_HH_
+#ifndef SRC_RASCAL_STRUCTURE_MANAGERS_ATOMIC_STRUCTURE_HH_
+#define SRC_RASCAL_STRUCTURE_MANAGERS_ATOMIC_STRUCTURE_HH_
 
-#include "rascal/basic_types.hh"
 #include "rascal/math/utils.hh"
+#include "rascal/utils/basic_types.hh"
 #include "rascal/utils/json_io.hh"
 
 #include <Eigen/Dense>
@@ -389,4 +389,4 @@ namespace rascal {
 
 }  // namespace rascal
 
-#endif  // SRC_RASCAL_ATOMIC_STRUCTURE_HH_
+#endif  // SRC_RASCAL_STRUCTURE_MANAGERS_ATOMIC_STRUCTURE_HH_

--- a/src/rascal/structure_managers/lattice.hh
+++ b/src/rascal/structure_managers/lattice.hh
@@ -1,5 +1,5 @@
 /**
- * @file   rascal/lattice.hh
+ * @file   rascal/structure_managers/lattice.hh
  *
  * @author  Felix Musil <felix.musil@epfl.ch>
  *
@@ -26,10 +26,10 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#ifndef SRC_RASCAL_LATTICE_HH_
-#define SRC_RASCAL_LATTICE_HH_
+#ifndef SRC_RASCAL_STRUCTURE_MANAGERS_LATTICE_HH_
+#define SRC_RASCAL_STRUCTURE_MANAGERS_LATTICE_HH_
 
-#include "rascal/atomic_structure.hh"
+#include "rascal/structure_managers/atomic_structure.hh"
 
 #include <Eigen/Dense>
 
@@ -250,4 +250,4 @@ namespace rascal {
   };
 }  // namespace rascal
 
-#endif  // SRC_RASCAL_LATTICE_HH_
+#endif  // SRC_RASCAL_STRUCTURE_MANAGERS_LATTICE_HH_

--- a/src/rascal/structure_managers/make_structure_manager.hh
+++ b/src/rascal/structure_managers/make_structure_manager.hh
@@ -29,9 +29,9 @@
 #define SRC_RASCAL_STRUCTURE_MANAGERS_MAKE_STRUCTURE_MANAGER_HH_
 
 #include "rascal/atomic_structure.hh"
-#include "rascal/json_io.hh"
 #include "rascal/structure_managers/property.hh"
 #include "rascal/structure_managers/structure_manager.hh"
+#include "rascal/utils/json_io.hh"
 #include "rascal/utils/utils.hh"
 
 #include <type_traits>

--- a/src/rascal/structure_managers/make_structure_manager.hh
+++ b/src/rascal/structure_managers/make_structure_manager.hh
@@ -32,7 +32,7 @@
 #include "rascal/json_io.hh"
 #include "rascal/structure_managers/property.hh"
 #include "rascal/structure_managers/structure_manager.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <type_traits>
 

--- a/src/rascal/structure_managers/make_structure_manager.hh
+++ b/src/rascal/structure_managers/make_structure_manager.hh
@@ -28,7 +28,7 @@
 #ifndef SRC_RASCAL_STRUCTURE_MANAGERS_MAKE_STRUCTURE_MANAGER_HH_
 #define SRC_RASCAL_STRUCTURE_MANAGERS_MAKE_STRUCTURE_MANAGER_HH_
 
-#include "rascal/atomic_structure.hh"
+#include "rascal/structure_managers/atomic_structure.hh"
 #include "rascal/structure_managers/property.hh"
 #include "rascal/structure_managers/structure_manager.hh"
 #include "rascal/utils/json_io.hh"

--- a/src/rascal/structure_managers/property.hh
+++ b/src/rascal/structure_managers/property.hh
@@ -33,8 +33,8 @@
 #define SRC_RASCAL_STRUCTURE_MANAGERS_PROPERTY_HH_
 
 #include "rascal/structure_managers/property_typed.hh"
-#include "rascal/utils/utils.hh"
 #include "rascal/utils/basic_types.hh"
+#include "rascal/utils/utils.hh"
 
 #include <Eigen/Dense>
 

--- a/src/rascal/structure_managers/property.hh
+++ b/src/rascal/structure_managers/property.hh
@@ -32,9 +32,9 @@
 #ifndef SRC_RASCAL_STRUCTURE_MANAGERS_PROPERTY_HH_
 #define SRC_RASCAL_STRUCTURE_MANAGERS_PROPERTY_HH_
 
-#include "rascal/basic_types.hh"
 #include "rascal/structure_managers/property_typed.hh"
 #include "rascal/utils/utils.hh"
+#include "rascal/utils/basic_types.hh"
 
 #include <Eigen/Dense>
 

--- a/src/rascal/structure_managers/property.hh
+++ b/src/rascal/structure_managers/property.hh
@@ -34,7 +34,7 @@
 
 #include "rascal/basic_types.hh"
 #include "rascal/structure_managers/property_typed.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <Eigen/Dense>
 

--- a/src/rascal/structure_managers/property_base.hh
+++ b/src/rascal/structure_managers/property_base.hh
@@ -30,8 +30,8 @@
 #ifndef SRC_RASCAL_STRUCTURE_MANAGERS_PROPERTY_BASE_HH_
 #define SRC_RASCAL_STRUCTURE_MANAGERS_PROPERTY_BASE_HH_
 
-#include "rascal/basic_types.hh"
 #include "rascal/structure_managers/structure_manager_base.hh"
+#include "rascal/utils/basic_types.hh"
 
 #include <array>
 #include <string>

--- a/src/rascal/structure_managers/property_block_sparse.hh
+++ b/src/rascal/structure_managers/property_block_sparse.hh
@@ -33,7 +33,7 @@
 #include "rascal/math/utils.hh"
 #include "rascal/structure_managers/cluster_ref_key.hh"
 #include "rascal/structure_managers/property_base.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <algorithm>
 #include <iterator>

--- a/src/rascal/structure_managers/property_typed.hh
+++ b/src/rascal/structure_managers/property_typed.hh
@@ -35,7 +35,7 @@
 #include "rascal/math/utils.hh"
 #include "rascal/structure_managers/cluster_ref_key.hh"
 #include "rascal/structure_managers/property_base.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 namespace rascal {
 

--- a/src/rascal/structure_managers/structure_manager.hh
+++ b/src/rascal/structure_managers/structure_manager.hh
@@ -34,11 +34,11 @@
  * Each actual implementation of a StructureManager is based on the given
  * interface
  */
-#include "rascal/json_io.hh"
 #include "rascal/structure_managers/cluster_ref_key.hh"
 #include "rascal/structure_managers/property.hh"
 #include "rascal/structure_managers/property_block_sparse.hh"
 #include "rascal/structure_managers/structure_manager_base.hh"
+#include "rascal/utils/json_io.hh"
 #include "rascal/utils/utils.hh"
 
 // Some data types and operations are based on the Eigen library

--- a/src/rascal/structure_managers/structure_manager.hh
+++ b/src/rascal/structure_managers/structure_manager.hh
@@ -39,7 +39,7 @@
 #include "rascal/structure_managers/property.hh"
 #include "rascal/structure_managers/property_block_sparse.hh"
 #include "rascal/structure_managers/structure_manager_base.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 // Some data types and operations are based on the Eigen library
 #include <Eigen/Dense>

--- a/src/rascal/structure_managers/structure_manager_centers.hh
+++ b/src/rascal/structure_managers/structure_manager_centers.hh
@@ -34,10 +34,10 @@
 
 // inclusion of librascal data structure, each manager is based on the interface
 // given in `structure_manager.hh`
-#include "rascal/atomic_structure.hh"
-#include "rascal/basic_types.hh"
-#include "rascal/lattice.hh"
+#include "rascal/structure_managers/atomic_structure.hh"
+#include "rascal/structure_managers/lattice.hh"
 #include "rascal/structure_managers/structure_manager.hh"
+#include "rascal/utils/basic_types.hh"
 #include "rascal/utils/json_io.hh"
 
 // data types and operations are based on the Eigen library

--- a/src/rascal/structure_managers/structure_manager_centers.hh
+++ b/src/rascal/structure_managers/structure_manager_centers.hh
@@ -36,9 +36,9 @@
 // given in `structure_manager.hh`
 #include "rascal/atomic_structure.hh"
 #include "rascal/basic_types.hh"
-#include "rascal/json_io.hh"
 #include "rascal/lattice.hh"
 #include "rascal/structure_managers/structure_manager.hh"
+#include "rascal/utils/json_io.hh"
 
 // data types and operations are based on the Eigen library
 #include <Eigen/Dense>

--- a/src/rascal/structure_managers/structure_manager_collection.hh
+++ b/src/rascal/structure_managers/structure_manager_collection.hh
@@ -28,8 +28,8 @@
 #ifndef SRC_RASCAL_STRUCTURE_MANAGERS_STRUCTURE_MANAGER_COLLECTION_HH_
 #define SRC_RASCAL_STRUCTURE_MANAGERS_STRUCTURE_MANAGER_COLLECTION_HH_
 
-#include "rascal/atomic_structure.hh"
 #include "rascal/math/utils.hh"
+#include "rascal/structure_managers/atomic_structure.hh"
 #include "rascal/structure_managers/make_structure_manager.hh"
 #include "rascal/structure_managers/property.hh"
 #include "rascal/structure_managers/structure_manager.hh"
@@ -41,7 +41,7 @@ namespace rascal {
 
   /**
    * A container to hold the multiple managers associated with one stack of
-   * managers and allows iterations over them. Each manager stack needs to
+   * managers and allows iterations over them. Each manager stack needs to be
    * initialized stack by stack. This class provides functions to do this job.
    *
    * ManagerCollection<StructureManagerCenter, AdaptorNeighbourList,

--- a/src/rascal/structure_managers/structure_manager_collection.hh
+++ b/src/rascal/structure_managers/structure_manager_collection.hh
@@ -35,7 +35,7 @@
 #include "rascal/structure_managers/property.hh"
 #include "rascal/structure_managers/structure_manager.hh"
 #include "rascal/structure_managers/updateable_base.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 namespace rascal {
 

--- a/src/rascal/structure_managers/structure_manager_collection.hh
+++ b/src/rascal/structure_managers/structure_manager_collection.hh
@@ -29,12 +29,12 @@
 #define SRC_RASCAL_STRUCTURE_MANAGERS_STRUCTURE_MANAGER_COLLECTION_HH_
 
 #include "rascal/atomic_structure.hh"
-#include "rascal/json_io.hh"
 #include "rascal/math/utils.hh"
 #include "rascal/structure_managers/make_structure_manager.hh"
 #include "rascal/structure_managers/property.hh"
 #include "rascal/structure_managers/structure_manager.hh"
 #include "rascal/structure_managers/updateable_base.hh"
+#include "rascal/utils/json_io.hh"
 #include "rascal/utils/utils.hh"
 
 namespace rascal {

--- a/src/rascal/utils/basic_types.hh
+++ b/src/rascal/utils/basic_types.hh
@@ -25,8 +25,8 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#ifndef SRC_RASCAL_BASIC_TYPES_HH_
-#define SRC_RASCAL_BASIC_TYPES_HH_
+#ifndef SRC_RASCAL_UTILS_BASIC_TYPES_HH_
+#define SRC_RASCAL_UTILS_BASIC_TYPES_HH_
 
 namespace rascal {
   /**
@@ -37,4 +37,4 @@ namespace rascal {
 
 }  // namespace rascal
 
-#endif  // SRC_RASCAL_BASIC_TYPES_HH_
+#endif  // SRC_RASCAL_UTILS_BASIC_TYPES_HH_

--- a/src/rascal/utils/json_io.cc
+++ b/src/rascal/utils/json_io.cc
@@ -1,5 +1,5 @@
 /**
- * @file   rascal/json_io.cc
+ * @file   rascal/utils/json_io.cc
  *
  * @author Till Junge <till.junge@epfl.ch>
  *
@@ -25,7 +25,7 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#include "rascal/json_io.hh"
+#include "rascal/utils/json_io.hh"
 
 namespace rascal {
   namespace json_io {

--- a/src/rascal/utils/json_io.hh
+++ b/src/rascal/utils/json_io.hh
@@ -1,5 +1,5 @@
 /**
- * @file   rascal/json_io.hh
+ * @file   rascal/utils/json_io.hh
  *
  * @author Markus Stricker <markus.stricker@epfl.ch>
  *
@@ -25,8 +25,8 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#ifndef SRC_RASCAL_JSON_IO_HH_
-#define SRC_RASCAL_JSON_IO_HH_
+#ifndef SRC_RASCAL_UTILS_JSON_IO_HH_
+#define SRC_RASCAL_UTILS_JSON_IO_HH_
 
 /*
  * interface to external header-library/header-class, which makes it easy to use
@@ -350,4 +350,4 @@ namespace rascal {
   }  // namespace json_io
 }  // namespace rascal
 
-#endif  // SRC_RASCAL_JSON_IO_HH_
+#endif  // SRC_RASCAL_UTILS_JSON_IO_HH_

--- a/src/rascal/utils/sparsify_fps.hh
+++ b/src/rascal/utils/sparsify_fps.hh
@@ -28,7 +28,7 @@
 #ifndef SRC_RASCAL_UTILS_SPARSIFY_FPS_HH_
 #define SRC_RASCAL_UTILS_SPARSIFY_FPS_HH_
 
-#include "rascal/basic_types.hh"
+#include "rascal/utils/basic_types.hh"
 
 #include <Eigen/Dense>
 

--- a/src/rascal/utils/units.cc
+++ b/src/rascal/utils/units.cc
@@ -1,5 +1,5 @@
 /**
- * @file   rascal/units.cc
+ * @file   rascal/utils/units.cc
  *
  * @author Till Junge <till.junge@epfl.ch>
  *
@@ -25,7 +25,7 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#include "rascal/units.hh"
+#include "rascal/utils/units.hh"
 
 #include <sstream>
 

--- a/src/rascal/utils/units.hh
+++ b/src/rascal/utils/units.hh
@@ -1,5 +1,5 @@
 /**
- * @file   rascal/units.hh
+ * @file   rascal/utils/units.hh
  *
  * @author Till Junge <till.junge@epfl.ch>
  *
@@ -25,8 +25,8 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#ifndef SRC_RASCAL_UNITS_HH_
-#define SRC_RASCAL_UNITS_HH_
+#ifndef SRC_RASCAL_UTILS_UNITS_HH_
+#define SRC_RASCAL_UTILS_UNITS_HH_
 
 #include <string>
 
@@ -115,4 +115,4 @@ namespace rascal {
 
 }  // namespace rascal
 
-#endif  // SRC_RASCAL_UNITS_HH_
+#endif  // SRC_RASCAL_UTILS_UNITS_HH_

--- a/src/rascal/utils/utils.cc
+++ b/src/rascal/utils/utils.cc
@@ -19,7 +19,7 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <cstdlib>
 #include <fstream>

--- a/src/rascal/utils/utils.hh
+++ b/src/rascal/utils/utils.hh
@@ -1,5 +1,5 @@
 /**
- * @file   rascal/utils.hh
+ * @file   rascal/utils/utils.hh
  *
  * @author Markus Stricker <markus.stricker@epfl.ch>
  * @author Felix Musil <felix.musil@epfl.ch>
@@ -25,8 +25,8 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#ifndef SRC_RASCAL_UTILS_HH_
-#define SRC_RASCAL_UTILS_HH_
+#ifndef SRC_RASCAL_UTILS_UTILS_HH_
+#define SRC_RASCAL_UTILS_UTILS_HH_
 
 #include <string>
 #include <tuple>
@@ -364,4 +364,4 @@ namespace rascal {
 
 }  // namespace rascal
 
-#endif  // SRC_RASCAL_UTILS_HH_
+#endif  // SRC_RASCAL_UTILS_UTILS_HH_

--- a/tests/test_adaptor_neighbour_list.cc
+++ b/tests/test_adaptor_neighbour_list.cc
@@ -30,7 +30,7 @@
 #include "test_adaptor.hh"
 #include "test_structure.hh"
 
-#include "rascal/atomic_structure.hh"
+#include "rascal/structure_managers/atomic_structure.hh"
 
 #include <boost/mpl/list.hpp>
 #include <boost/test/unit_test.hpp>

--- a/tests/test_atomic_structure.cc
+++ b/tests/test_atomic_structure.cc
@@ -25,7 +25,7 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#include "rascal/atomic_structure.hh"
+#include "rascal/structure_managers/atomic_structure.hh"
 
 #include <boost/test/unit_test.hpp>
 

--- a/tests/test_calculator.hh
+++ b/tests/test_calculator.hh
@@ -34,7 +34,6 @@
 #include "test_structure.hh"
 
 #include "rascal/atomic_structure.hh"
-#include "rascal/json_io.hh"
 #include "rascal/representations/calculator_base.hh"
 #include "rascal/representations/calculator_sorted_coulomb.hh"
 #include "rascal/representations/calculator_spherical_covariants.hh"
@@ -42,6 +41,7 @@
 #include "rascal/representations/calculator_spherical_invariants.hh"
 #include "rascal/structure_managers/cluster_ref_key.hh"
 #include "rascal/structure_managers/structure_manager_collection.hh"
+#include "rascal/utils/json_io.hh"
 #include "rascal/utils/utils.hh"
 
 #include <memory>

--- a/tests/test_calculator.hh
+++ b/tests/test_calculator.hh
@@ -33,12 +33,12 @@
 #include "test_math.hh"
 #include "test_structure.hh"
 
-#include "rascal/atomic_structure.hh"
 #include "rascal/representations/calculator_base.hh"
 #include "rascal/representations/calculator_sorted_coulomb.hh"
 #include "rascal/representations/calculator_spherical_covariants.hh"
 #include "rascal/representations/calculator_spherical_expansion.hh"
 #include "rascal/representations/calculator_spherical_invariants.hh"
+#include "rascal/structure_managers/atomic_structure.hh"
 #include "rascal/structure_managers/cluster_ref_key.hh"
 #include "rascal/structure_managers/structure_manager_collection.hh"
 #include "rascal/utils/json_io.hh"

--- a/tests/test_calculator.hh
+++ b/tests/test_calculator.hh
@@ -42,7 +42,7 @@
 #include "rascal/representations/calculator_spherical_invariants.hh"
 #include "rascal/structure_managers/cluster_ref_key.hh"
 #include "rascal/structure_managers/structure_manager_collection.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <memory>
 #include <tuple>

--- a/tests/test_lattice.hh
+++ b/tests/test_lattice.hh
@@ -28,8 +28,8 @@
 #ifndef TESTS_TEST_LATTICE_HH_
 #define TESTS_TEST_LATTICE_HH_
 
-#include "rascal/atomic_structure.hh"
-#include "rascal/lattice.hh"
+#include "rascal/structure_managers/atomic_structure.hh"
+#include "rascal/structure_managers/lattice.hh"
 
 namespace rascal {
 

--- a/tests/test_math.hh
+++ b/tests/test_math.hh
@@ -29,12 +29,12 @@
 #ifndef TESTS_TEST_MATH_HH_
 #define TESTS_TEST_MATH_HH_
 
-#include "rascal/json_io.hh"
 #include "rascal/math/bessel.hh"
 #include "rascal/math/gauss_legendre.hh"
 #include "rascal/math/hyp1f1.hh"
 #include "rascal/math/spherical_harmonics.hh"
 #include "rascal/math/utils.hh"
+#include "rascal/utils/json_io.hh"
 #include "rascal/utils/utils.hh"
 
 #include <boost/test/unit_test.hpp>

--- a/tests/test_math.hh
+++ b/tests/test_math.hh
@@ -35,7 +35,7 @@
 #include "rascal/math/hyp1f1.hh"
 #include "rascal/math/spherical_harmonics.hh"
 #include "rascal/math/utils.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <boost/test/unit_test.hpp>
 

--- a/tests/test_rascal_utils.cc
+++ b/tests/test_rascal_utils.cc
@@ -26,7 +26,7 @@
  */
 
 #include "rascal/representations/calculator_spherical_expansion.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <boost/mpl/list.hpp>
 #include <boost/test/unit_test.hpp>

--- a/tests/test_structure.hh
+++ b/tests/test_structure.hh
@@ -43,7 +43,7 @@
 #include "rascal/structure_managers/structure_manager_base.hh"
 #include "rascal/structure_managers/structure_manager_centers.hh"
 #include "rascal/structure_managers/structure_manager_lammps.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 namespace rascal {
 

--- a/tests/test_utils.cc
+++ b/tests/test_utils.cc
@@ -28,7 +28,7 @@
 #include "rascal/structure_managers/cluster_ref_key.hh"
 #include "rascal/structure_managers/structure_manager.hh"
 #include "rascal/structure_managers/structure_manager_centers.hh"
-#include "rascal/utils.hh"
+#include "rascal/utils/utils.hh"
 
 #include <boost/test/unit_test.hpp>
 


### PR DESCRIPTION
As discussed in #243:
All hh/cc files are now not in the base `src/rascal/` folder anymore, but in `utils` and `structure_manager`

Rest of the changes are the changes in includes and header guards.