### PR TITLE
Do not look for PythonLib unless we are building the bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,9 +103,6 @@ endif()
 
 ########## START CONFIGURATION ##########
 
-# Find correct python version
-find_package(PythonLibsNew 3 MODULE REQUIRED)
-
 # set the name of the c++ libraries
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR
     CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")


### PR DESCRIPTION
The `find_package(PythonLibsNew 3 MODULE REQUIRED)` is duplicated below, after `if (BUILD_BINDINGS)`. I guess this is a merge conflict scorie
