### PR TITLE
boost include

### DIFF
--- a/BOOST.md
+++ b/BOOST.md
@@ -10,20 +10,20 @@ sudo apt-get install libboost-test-dev
 Depending on your version of these distributions, you might not get a recent enough verison of the boost library.
 
 ## Mac
-It seems that the brew recepy of boost is broken (compilation errors). Custom or Conda installations are advised. 
+It seems that the brew recepy of boost is broken (compilation errors). Custom or Conda installations are advised.
 
 ## Custom installation
 We use 7z to unpack (sudo apt-get install p7zip-full to install on ubuntu)
 ```
 export BOOST_DIR=/path/to/download/directory
-wget https://sourceforge.net/projects/boost/files/boost/1.67.0/boost_1_67_0.7z/download -O $BOOST_DIR/boost_1_67_0.7z
-7z x $BOOST_DIR/boost_1_67_0.7z
-cd $BOOST_DIR/boost_1_67_0
+wget https://sourceforge.net/projects/boost/files/boost/1.64.0/boost_1_64_0.7z/download -O $BOOST_DIR/boost_1_64_0.7z
+7z x $BOOST_DIR/boost_1_64_0.7z
+cd $BOOST_DIR/boost_1_64_0
 mkdir boost_root
-./bootstrap.sh --with-libraries=test --with-toolset=gcc --prefix=$BOOST_DIR/boost_root 
+./bootstrap.sh --with-libraries=test --with-toolset=gcc --prefix=$BOOST_DIR/boost_1_64_0/boost_root
 ./b2 install
 export Boost_NO_SYSTEM_PATHS=ON
-export BOOST_ROOT=$BOOST_DIR/boost_root
+export BOOST_ROOT=$BOOST_DIR/boost_1_64_0/boost_root
 ```
 Cmake FindBoost might not find this installation of Boost Test so we set Boost_NO_SYSTEM_PATHS to avoid finding another installation of Boost and we set BOOST_ROOT to this new installation.
 
@@ -35,7 +35,7 @@ export MINICONDA_DOWNLOAD_DIR=/path/to/download/directory
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O $MINICONDA_DOWNLOAD_DIR/miniconda.sh
 bash $MINICONDA_DOWNLOAD_DIR/miniconda.sh
 bash $MINICONDA_DOWNLOAD_DIR/miniconda.sh -b -p $HOME/miniconda
-export PATH="$HOME/miniconda/bin:$PATH" 
+export PATH="$HOME/miniconda/bin:$PATH"
 echo 'export PATH="$HOME/miniconda/bin:$PATH"' >> $HOME/.bashrc
 source $HOME/.bashrc
 conda create -n myenv python=3.6
@@ -45,7 +45,7 @@ conda create -n myenv python=3.6
 ```
 source activate myenv
 conda install -c conda-forge boost
-export Boost_NO_SYSTEM_PATHS=ON 
+export Boost_NO_SYSTEM_PATHS=ON
 export BOOST_ROOT=/path/to/myenv
 ```
 Following the previous example, /path/to/myenv -> $HOME/miniconda/envs/myenv.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,8 +36,6 @@ target_include_directories(rascal_tests_main SYSTEM PRIVATE ${Boost_INCLUDE_DIR}
 target_compile_definitions(rascal_tests_main PUBLIC -DBOOST_TEST_DYN_LINK)
 target_link_libraries(rascal_tests_main ${Boost_LIBRARIES} "${LIBRASCAL_NAME}")
 
-message(STATUS "+++++++++++ ${Boost_INCLUDE_DIR}")
-
 file(GLOB tests "${CMAKE_CURRENT_SOURCE_DIR}/test_*.cc")
 
 foreach(_file_ ${tests})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,17 +29,25 @@ else()
     set(TEST_RUNNER "")
 endif()
 
+
 add_library(rascal_tests_main STATIC helpers/tests_main.cc)
+# make sure all tests include the boost that has been found
+target_include_directories(rascal_tests_main SYSTEM PRIVATE ${Boost_INCLUDE_DIR})
 target_compile_definitions(rascal_tests_main PUBLIC -DBOOST_TEST_DYN_LINK)
 target_link_libraries(rascal_tests_main ${Boost_LIBRARIES} "${LIBRASCAL_NAME}")
+
+message(STATUS "+++++++++++ ${Boost_INCLUDE_DIR}")
 
 file(GLOB tests "${CMAKE_CURRENT_SOURCE_DIR}/test_*.cc")
 
 foreach(_file_ ${tests})
     get_filename_component(_name_ ${_file_} NAME_WE)
     add_executable(${_name_} ${_file_})
+    # make sure all tests include the boost that has been found
+    target_include_directories(${_name_} SYSTEM PRIVATE ${Boost_INCLUDE_DIR})
     target_link_libraries(${_name_} rascal_tests_main)
     target_compile_options(${_name_} PRIVATE -Werror)
+
 
     add_test(
         NAME ${_name_}


### PR DESCRIPTION
For custom boost path, typically set with BOOST_ROOT and different from /usr of /usr/local, make sure the include path are properly set when compiling the tests.

