### PR TITLE
Add a CI builder to collect coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,20 +151,25 @@ jobs:
           name: Install Python dependencies
           command: |
             python3.6 -m pip install -r requirements.txt
-            python3.6 -m pip install codecov
+            python3.6 -m pip install codecov coverage
       - run:
           name: Configure
           command: |
             mkdir build && cd build
-            cmake -DBUILD_BINDINGS=OFF -DBUILD_TESTS=ON \
+            cmake -DBUILD_BINDINGS=ON -DBUILD_TESTS=ON \
                   -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-coverage" \
                   ..
       - run:
           name: Build
           command: cd build && make
       - run:
-          name: Run tests
+          name: Run C++ tests
           command: cd build && ctest
+      - run:
+          name: Run Python tests
+          command: coverage run tests/python/python_binding_tests.py
+          environment:
+            PYTHONPATH: build/
       - run:
           name: Collect and upload coverage
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,37 @@ jobs:
           command: |
             cd build && make pretty-cpp && git diff --exit-code
 
+  # Special job collecting code coverage
+  coverage:
+    docker:
+    - image: cosmoepfl/rascal-ci:3
+    steps:
+      - checkout
+      - run:
+          name: Install Python dependencies
+          command: |
+            python3.6 -m pip install -r requirements.txt
+            python3.6 -m pip install codecov
+      - run:
+          name: Configure
+          command: |
+            mkdir build && cd build
+            cmake -DBUILD_BINDINGS=OFF -DBUILD_TESTS=ON \
+                  -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-coverage" \
+                  ..
+      - run:
+          name: Build
+          command: cd build && make
+      - run:
+          name: Run tests
+          command: cd build && ctest
+      - run:
+          name: Collect and upload coverage
+          command: |
+            find . -type f -name '*.gcno' -exec gcov-7 -pb {} +
+            rm -f \#usr\#*.gcov
+            rm -f *\#external\#*.gcov
+            codecov -X gcov
 
 workflows:
   version: 2
@@ -150,6 +181,7 @@ workflows:
       - docs
       - pretty
       - valgrind
+      - coverage
       - gcc-5
       - gcc-9
       - gcc-9-debug

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  ignore:
+    - tests/.*
+    - examples/.*
+    - build/external/.*
+  status:
+    project:
+      default:
+        target: 82%
+    patch: off
+
+comment: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ coverage:
   status:
     project:
       default:
-        target: 82%
+        target: 80%
     patch: off
 
 comment: off


### PR DESCRIPTION
Code coverage measure how much of the source code is covered by the tests. While it is not a perfect way to ensure that the code is bug-free, tracking coverage allows to know if some part of the code are not tested at all.
