### PR TITLE
Bugfix/gaussian sigma

### DIFF
--- a/bindings/rascal/representations/spherical_covariants.py
+++ b/bindings/rascal/representations/spherical_covariants.py
@@ -60,7 +60,7 @@ class SphericalCovariants(object):
 
     def __init__(self, interaction_cutoff, cutoff_smooth_width,
                  max_radial, max_angular, gaussian_sigma_type,
-                 gaussian_sigma_constant=0., n_species=1,
+                 gaussian_sigma_constant=0.3, n_species=1,
                  cutoff_function_type="ShiftedCosine", normalize=True,
                  radial_basis="GTO",
                  soap_type="LambdaSpectrum", inversion_symmetry=True,

--- a/bindings/rascal/representations/spherical_expansion.py
+++ b/bindings/rascal/representations/spherical_expansion.py
@@ -82,7 +82,7 @@ class SphericalExpansion(object):
 
     def __init__(self, interaction_cutoff, cutoff_smooth_width,
                  max_radial, max_angular, gaussian_sigma_type,
-                 gaussian_sigma_constant=0.,
+                 gaussian_sigma_constant=0.3,
                  cutoff_function_type="ShiftedCosine",
                  n_species=1, radial_basis="GTO",
                  method='thread', n_workers=1, disable_pbar=False,

--- a/bindings/rascal/representations/spherical_invariants.py
+++ b/bindings/rascal/representations/spherical_invariants.py
@@ -94,7 +94,7 @@ class SphericalInvariants(object):
 
     def __init__(self, interaction_cutoff, cutoff_smooth_width,
                  max_radial, max_angular, gaussian_sigma_type,
-                 gaussian_sigma_constant=0., n_species=1,
+                 gaussian_sigma_constant=0.3, n_species=1,
                  cutoff_function_type="ShiftedCosine",
                  soap_type="PowerSpectrum", inversion_symmetry=True,
                  radial_basis="GTO", normalize=True,

--- a/src/rascal/representations/calculator_spherical_expansion.hh
+++ b/src/rascal/representations/calculator_spherical_expansion.hh
@@ -200,6 +200,12 @@ namespace rascal {
       explicit AtomicSmearingSpecification(const Hypers_t & hypers) {
         this->constant_gaussian_sigma =
             hypers.at("gaussian_sigma").at("value").get<double>();
+        if (this->constant_gaussian_sigma < 5e-2) {
+          std::stringstream err_str{};
+          err_str << "Constant gaussian sigma is too small: "
+                  << this->constant_gaussian_sigma << " < 5e-2";
+          throw std::runtime_error(err_str.str());
+        }
       }
       template <size_t Order, size_t Layer>
       double


### PR DESCRIPTION
Improve user friendliness of the the Spherical* family by setting a more sensible default to gaussian_sigma_constant on the python side and throwing an error if it is too small on the c++ side.
