### PR TITLE
Feat/fix property order 0

### DIFF
--- a/src/rascal/structure_managers/property_typed.hh
+++ b/src/rascal/structure_managers/property_typed.hh
@@ -152,6 +152,12 @@ namespace rascal {
    * one only wants the `size` and that it the default optiont. But e.g. for
    * `cluster_indices` the size needs to include space for the number of atoms
    * plus ghosts.
+   *
+   * Special cases exist for Order=0 properties which are related to the
+   * structure. Unlike higher orders, it does not support multiple
+   * layers, therefore its layer is set to 0. The underlying data can be
+   * directly accessed with operator() for individual elements, operator[0]
+   * to get a Map<Matrix> and .view() to get a Map<const Matrix>.
    */
   template <typename T, size_t Order_, class Manager>
   class TypedProperty : public PropertyBase {
@@ -170,6 +176,7 @@ namespace rascal {
     constexpr static size_t Order{Order_};
     constexpr static bool IsOrderOne{Order == 1};
 
+    template <size_t Order__ = Order, std::enable_if_t<(Order__ >= 1), int> = 0>
     TypedProperty(Manager_t & manager, Dim_t nb_row, Dim_t nb_col = 1,
                   std::string metadata = "no metadata",
                   bool exclude_ghosts = false)
@@ -178,6 +185,18 @@ namespace rascal {
                  nb_col,
                  Order,
                  manager.template cluster_layer_from_order<Order>(),
+                 metadata},
+          type_id{typeid(Self_t).name()}, exclude_ghosts{exclude_ghosts} {}
+
+    template <size_t Order__ = Order, std::enable_if_t<(Order__ == 0), int> = 0>
+    TypedProperty(Manager_t & manager, Dim_t nb_row, Dim_t nb_col = 1,
+                  std::string metadata = "no metadata",
+                  bool exclude_ghosts = false)
+        : Parent{static_cast<StructureManagerBase &>(manager),
+                 nb_row,
+                 nb_col,
+                 Order,
+                 0,
                  metadata},
           type_id{typeid(Self_t).name()}, exclude_ghosts{exclude_ghosts} {}
 
@@ -272,7 +291,16 @@ namespace rascal {
     }
 
     //! Returns the size of one component
-    size_t size() const { return this->values.size() / this->get_nb_comp(); }
+    template <size_t Order__ = Order, std::enable_if_t<(Order__ == 0), int> = 0>
+    size_t size() const {
+      return 1;
+    }
+
+    //! Returns the size of one component
+    template <size_t Order__ = Order, std::enable_if_t<(Order__ > 0), int> = 0>
+    size_t size() const {
+      return this->values.size() / this->get_nb_comp();
+    }
 
     /**
      * shortens the vector so that the manager can push_back into it (capacity
@@ -282,8 +310,9 @@ namespace rascal {
 
     /* ---------------------------------------------------------------------- */
     //! Property accessor by cluster ref
-    template <size_t CallerLayer>
-    reference operator[](const ClusterRefKey<Order, CallerLayer> & id) {
+    template <size_t CallerLayer, size_t Order__ = Order>
+    std::enable_if_t<(Order__ > 0), reference>  // NOLINT
+    operator[](const ClusterRefKey<Order, CallerLayer> & id) {
       // You are trying to access a property that does not exist at this depth
       // in the adaptor stack.
       assert(static_cast<int>(CallerLayer) >= this->get_property_layer());
@@ -303,6 +332,13 @@ namespace rascal {
     reference operator[](size_t index) {
       return Value_t::get_ref(this->values[index * this->get_nb_comp()],
                               this->get_nb_row(), this->get_nb_col());
+    }
+
+    //! Direct accessor for property of order == 0
+    template <size_t Order__ = Order, std::enable_if_t<(Order__ == 0), int> = 0>
+    T & operator()(int i_row, int i_col) {
+      return Value_t::get_ref(this->values[0], this->get_nb_row(),
+                              this->get_nb_col())(i_row, i_col);
     }
 
     void fill_dense_feature_matrix(Eigen::Ref<Matrix_t> features) const {

--- a/tests/test_properties.cc
+++ b/tests/test_properties.cc
@@ -145,6 +145,54 @@ namespace rascal {
       std::cout << " finished." << std::endl;
     }
   }
+
+  /**
+   *  Test property of order 0 for initialization, access, and direct access.
+   */
+  BOOST_FIXTURE_TEST_CASE_TEMPLATE(structure_dynamic_property_test, Fix,
+                                   atom_vector_property_fixtures, Fix) {
+    auto && property = Fix::structure_dynamic_property;
+    property.resize();
+    property.setZero();
+    // check that basic initialization works
+    for (int i_col{0}; i_col < property.get_nb_col(); ++i_col) {
+      for (int i_row{0}; i_row < property.get_nb_row(); ++i_row) {
+        BOOST_CHECK(property(i_row, i_col) == 0);
+        property(i_row, i_col) = static_cast<double>(i_row * i_col);
+      }
+    }
+    // check direct access to the property values
+    for (int i_col{0}; i_col < property.get_nb_col(); ++i_col) {
+      for (int i_row{0}; i_row < property.get_nb_row(); ++i_row) {
+        BOOST_CHECK(property(i_row, i_col) ==
+                    static_cast<double>(i_row * i_col));
+      }
+    }
+
+    property.set_shape(3, 6);
+    property.resize();
+    double counter{0};
+    for (int i_col{0}; i_col < property.get_nb_col(); ++i_col) {
+      for (int i_row{0}; i_row < property.get_nb_row(); ++i_row) {
+        property(i_row, i_col) = counter;
+        counter++;
+      }
+    }
+    // 3 different ways to get the underlying data from property
+    auto && values_0 = property[0];
+    auto && values_1 = property.back();
+    auto && values_2 = property.view();
+    counter = 0;
+    for (int i_col{0}; i_col < property.get_nb_col(); ++i_col) {
+      for (int i_row{0}; i_row < property.get_nb_row(); ++i_row) {
+        BOOST_CHECK(values_0(i_row, i_col) == counter);
+        BOOST_CHECK(values_1(i_row, i_col) == counter);
+        BOOST_CHECK(values_2(0, counter) == counter);
+        counter++;
+      }
+    }
+  }
+
   BOOST_FIXTURE_TEST_CASE_TEMPLATE(fill_sequence_test, Fix,
                                    atom_vector_property_fixtures, Fix) {
     Fix::atom_scalar_property.fill_sequence();

--- a/tests/test_properties.hh
+++ b/tests/test_properties.hh
@@ -148,6 +148,9 @@ namespace rascal {
     using Manager_t = typename Parent::Manager_t;
     using ManagerPtr_t = std::shared_ptr<Manager_t>;
 
+    using StructureDynamicProperty_t =
+        typename Manager_t::template Property_t<double, 0, Eigen::Dynamic,
+                                                Eigen::Dynamic>;
     using AtomScalarProperty_t =
         typename Manager_t::template Property_t<double, 1>;
     using AtomVectorProperty_t =
@@ -167,7 +170,9 @@ namespace rascal {
     std::string atom_dynamic_vector_property_metadata{"distances"};
 
     AtomPropertyFixture()
-        : StackFixture{}, atom_scalar_property{*this->manager, "dummy_scalar"},
+        : StackFixture{}, structure_dynamic_property{*this->manager,
+                                                     "dummy_structure_dynamic"},
+          atom_scalar_property{*this->manager, "dummy_atom_scalar"},
           atom_vector_property{*this->manager, atom_vector_property_metadata},
           atom_dynamic_scalar_property{
               *this->manager, 1, 1, atom_dynamic_vector_unit_property_metadata},
@@ -178,6 +183,7 @@ namespace rascal {
                                        atom_dynamic_vector_property_metadata},
           sparse_atom_scalar_property{*this->manager} {}
 
+    StructureDynamicProperty_t structure_dynamic_property;
     AtomScalarProperty_t atom_scalar_property;
     AtomVectorProperty_t atom_vector_property;
     AtomDynamicProperty_t atom_dynamic_scalar_property;


### PR DESCRIPTION
Fix the construction of Property<Order==0> and add a dedicated access routine. Some other functionalities are suppressed with SFINAE because they don't make sense in this context.

