### PR TITLE
Make tests compile in gcc 10

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && \
     apt-get install -y \
         gcc-5 g++-5 \
         gcc-9 g++-9 \
+        gcc-10 g++-10 \
         clang-4.0 \
         clang-9 \
         clang-format-9

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -24,7 +24,6 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -  && \
 RUN apt-get update && \
     apt-get install -y \
         gcc-5 g++-5 \
-        gcc-9 g++-9 \
         gcc-10 g++-10 \
         clang-4.0 \
         clang-9 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 # indicated by the CC/CXX environment variables.
 default_job: &default_job
   docker:
-    - image: cosmoepfl/rascal-ci:4
+    - image: cosmoepfl/rascal-ci:5
   steps:
     - checkout
     - run:
@@ -69,8 +69,8 @@ jobs:
     <<: *default_job
   valgrind:
     environment:
-      CC: gcc-9
-      CXX: g++-9
+      CC: gcc-10
+      CXX: g++-10
       CMAKE_EXTRA: -DRASCAL_TESTS_USE_VALGRIND=ON -DTYPE_ARCHITECTURE=core2
     <<: *default_job
 
@@ -188,8 +188,8 @@ workflows:
       - valgrind
       - coverage
       - gcc-5
-      - gcc-10-debug
       - gcc-10
+      - gcc-10-debug
       - clang-4
       - clang-9
       - clang-9-debug

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 # indicated by the CC/CXX environment variables.
 default_job: &default_job
   docker:
-    - image: cosmoepfl/rascal-ci:3
+    - image: cosmoepfl/rascal-ci:4
   steps:
     - checkout
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,15 +40,15 @@ jobs:
       CC: gcc-5
       CXX: g++-5
     <<: *default_job
-  gcc-9:
+  gcc-10:
     environment:
-      CC: gcc-9
-      CXX: g++-9
+      CC: gcc-10
+      CXX: g++-10
     <<: *default_job
-  gcc-9-debug:
+  gcc-10-debug:
     environment:
-      CC: gcc-9
-      CXX: g++-9
+      CC: gcc-10
+      CXX: g++-10
       CMAKE_EXTRA: -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG=
     <<: *default_job
   clang-4:
@@ -188,8 +188,8 @@ workflows:
       - valgrind
       - coverage
       - gcc-5
-      - gcc-9
-      - gcc-9-debug
+      - gcc-10-debug
+      - gcc-10
       - clang-4
       - clang-9
       - clang-9-debug

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ coverage:
   status:
     project:
       default:
-        target: 80%
+        target: 75%
     patch: off
 
 comment: off

--- a/src/rascal/utils/key_standardisation.hh
+++ b/src/rascal/utils/key_standardisation.hh
@@ -35,6 +35,8 @@
 
 namespace rascal {
 
+  using std::size_t;
+
   template <typename T, size_t MaxOrder>
   class KeyStandardisation {
     static_assert(std::is_arithmetic<T>::value,


### PR DESCRIPTION
Fix #308 

Also in this PR, replace gcc-9 with gcc-10 as the latest GCC version (it seems to be the default in Ubuntu now as well: https://packages.ubuntu.com/groovy/gcc).

Tasks before review:

- [x] Add tests, examples, and complete documentation of any added functionality
    - [x] For bugfix pull requests, list here which tests have been added or re-enabled
          to verify the fix and catch future regressions as well as similar bugs
          elsewhere in the code.
       - gcc-10 tests on circleci (in progress)
- [x] Run `make lint` on the project, ensure it passes

