### PR TITLE
Allow higher ase versions in requirements_pip.txt

### DIFF
--- a/requirements_pip.txt
+++ b/requirements_pip.txt
@@ -2,4 +2,4 @@
 numpy>=1.16.0
 scipy>=1.2.0
 matplotlib>=2.0.0
-ase==3.19.0
+ase>=3.19.0


### PR DESCRIPTION
Installing librascal with pip downgrade my ASE. Reinstalling with a more recent version did not encounter any problem, and it seems bad practice to be tied to an older version (especially with patchlevel fully specified).

----

Tasks before review:

- [ ] Add tests, examples, and complete documentation of any added functionality
    - [ ] Make sure the autogenerated documentation appears in Sphinx and is
          formatted correctly (ask @max-veit if you need help with this task).
    - [ ] Write additional documentation in the Sphinx (not docstrings!) to
          explain the feature and its usage in plain English
    - [ ] Make sure the examples run (!) and produce the expected output
    - [ ] For bugfix pull requests, list here which tests have been added or re-enabled
          to verify the fix and catch future regressions as well as similar bugs
          elsewhere in the code.
- [ ] Run `make lint` on the project, ensure it passes
    - [ ] Run `make pretty-cpp` and `make pretty-python`, check that the
          auto-formatting is sensible
    - [ ] Review variable names, make sure they're descriptive (ask a friend)
    - [ ] Review all TODOs, convert to issues wherever possible
    - [ ] Make sure draft, in-progress, and commented-out code is moved to its
          own branch
- [ ] If committing any code in Jupyter/IPython notebooks, install and run `nbstripout`
- [ ] Merge with master and resolve any conflicts
- [ ] (anything else that's still in progress)

