### PR TITLE
Quick fix for circular imports

### DIFF
--- a/bindings/rascal/models/__init__.py
+++ b/bindings/rascal/models/__init__.py
@@ -1,3 +1,2 @@
-from .sparse_points import SparsePoints
 from .krr import train_gap_model, KRR
 from .kernels import Kernel

--- a/bindings/rascal/utils/__init__.py
+++ b/bindings/rascal/utils/__init__.py
@@ -1,7 +1,3 @@
-from .fps import fps, FPSFilter
-from ..lib._rascal.utils import ostream_redirect
-from ..lib import utils
-from copy import deepcopy
 from .io import (
     BaseIO,
     to_dict,
@@ -11,6 +7,10 @@ from .io import (
     dump_obj,
     load_obj,
 )
+from .fps import fps, FPSFilter
+from ..lib._rascal.utils import ostream_redirect
+from ..lib import utils
+from copy import deepcopy
 from .cur import CURFilter
 from .scorer import get_score, print_score
 

--- a/bindings/rascal/utils/__init__.py
+++ b/bindings/rascal/utils/__init__.py
@@ -7,27 +7,14 @@ from .io import (
     dump_obj,
     load_obj,
 )
+from .misc import is_notebook
+
+# Warning potential dependency loop: FPS imports models, which imports KRR,
+# which imports this file again
 from .fps import fps, FPSFilter
+
+# function to redirect c++'s standard output to python's one
 from ..lib._rascal.utils import ostream_redirect
-from ..lib import utils
 from copy import deepcopy
 from .cur import CURFilter
 from .scorer import get_score, print_score
-
-# function to redirect c++'s standard output to python's one
-ostream_redirect = utils.__dict__["ostream_redirect"]
-
-
-def is_notebook():
-    from IPython import get_ipython
-
-    try:
-        shell = get_ipython().__class__.__name__
-        if shell == "ZMQInteractiveShell":
-            return True  # Jupyter notebook or qtconsole
-        elif shell == "TerminalInteractiveShell":
-            return False  # Terminal running IPython
-        else:
-            return False  # Other type (?)
-    except NameError:
-        return False  # Probably standard Python interpreter

--- a/bindings/rascal/utils/fps.py
+++ b/bindings/rascal/utils/fps.py
@@ -1,5 +1,6 @@
 from .io import BaseIO
 from ..lib import sparsification
+from ..models.sparse_points import SparsePoints
 
 from .filter_utils import (
     get_index_mappings_sample_per_species,
@@ -236,7 +237,6 @@ class FPSFilter(BaseIO):
             raise NotImplementedError("method: {}".format(self.act_on))
 
     def filter(self, managers, n_select=None):
-        from ..models import SparsePoints
 
         if n_select is None:
             n_select = self.Nselect

--- a/bindings/rascal/utils/misc.py
+++ b/bindings/rascal/utils/misc.py
@@ -1,0 +1,17 @@
+"""Miscellaneous useful utilities"""
+
+
+def is_notebook():
+    """Is this being run inside an IPython Notebook?"""
+    from IPython import get_ipython
+
+    try:
+        shell = get_ipython().__class__.__name__
+        if shell == "ZMQInteractiveShell":
+            return True  # Jupyter notebook or qtconsole
+        elif shell == "TerminalInteractiveShell":
+            return False  # Terminal running IPython
+        else:
+            return False  # Other type (?)
+    except NameError:
+        return False  # Probably standard Python interpreter

--- a/examples/MLIP_example.ipynb
+++ b/examples/MLIP_example.ipynb
@@ -43,7 +43,8 @@
     "import json\n",
     "\n",
     "from rascal.representations import SphericalInvariants\n",
-    "from rascal.models import Kernel, SparsePoints, train_gap_model\n",
+    "from rascal.models import Kernel, train_gap_model\n",
+    "from rascal.models.sparse_points import SparsePoints\n",
     "from rascal.models.IP_ase_interface import ASEMLCalculator\n",
     "from rascal.neighbourlist import AtomsList\n",
     "from rascal.utils import from_dict, to_dict, CURFilter, dump_obj, load_obj, get_score, print_score"

--- a/examples/Spherical_invariants_and_database_exploration.ipynb
+++ b/examples/Spherical_invariants_and_database_exploration.ipynb
@@ -45,7 +45,8 @@
     "from tqdm.notebook import tqdm\n",
     "\n",
     "from rascal.representations import SphericalInvariants\n",
-    "from rascal.models import Kernel, KRR, train_gap_model, SparsePoints\n",
+    "from rascal.models import Kernel, KRR, train_gap_model\n",
+    "from rascal.models.sparse_points import SparsePoints\n",
     "from rascal.utils import from_dict, to_dict, CURFilter, FPSFilter, get_score, print_score"
    ]
   },

--- a/tests/python/python_models_test.py
+++ b/tests/python/python_models_test.py
@@ -1,5 +1,6 @@
 from rascal.representations import SphericalInvariants
-from rascal.models import Kernel, SparsePoints
+from rascal.models import Kernel
+from rascal.models.sparse_points import SparsePoints
 from rascal.models.kernels import compute_numerical_kernel_gradients
 from rascal.utils import from_dict, to_dict
 from test_utils import load_json_frame, BoxList, Box, compute_relative_error

--- a/tests/python/python_representation_calculator_test.py
+++ b/tests/python/python_representation_calculator_test.py
@@ -4,7 +4,8 @@ from rascal.representations import (
     SphericalInvariants,
 )
 from rascal.utils import from_dict, to_dict, FPSFilter
-from rascal.models import Kernel, SparsePoints
+from rascal.models import Kernel
+from rascal.models.sparse_points import SparsePoints
 from test_utils import load_json_frame, BoxList, Box, dot
 import unittest
 import numpy as np


### PR DESCRIPTION
Fix #294 

I can't guarantee that this fixes _all_ our circular import problems, but I think this addresses the one triggered by trying to run

```python
from rascal.models import <something>
```

I'm not sure how exactly to test this -- it pops up pretty randomly when changing something in the Python code, and depends on import ordering (which is a nightmare), so somehow it has not been caught by the Python binding tests until now. Suggestions welcome.