### PR TITLE
Quick fixes for automated build issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,9 @@ jobs:
 
   # Special job only building the documentation
   docs:
+    environment:
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8
     docker:
     - image: cosmoepfl/rascal-ci:3
     steps:
@@ -103,6 +106,9 @@ jobs:
 
   # Special job only linting the code
   lint:
+    environment:
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8
     docker:
     - image: cosmoepfl/rascal-ci:3
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,14 +6,15 @@ jupyter
 matplotlib
 #qml
 # tqdm
-# for documentation
-sphinx==4.0.1
-breathe==4.30.0
+# Developers tools for compiling documentation
+sphinx>=2.1.2
+breathe>=4.14.1
+# Jinja2 v3 breaks nbsphinx
 jinja2==2.11.3
 sphinx_rtd_theme
-nbsphinx==0.8.5
-pygments==2.9.0
-docutils==0.17
+nbsphinx>=0.8.1
+pygments>=2.4.1
+# Developers tools for linting and formatting
 cpplint==1.5.5
 black==20.8b1
 # Developers tools - data generation scripts

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pygments>=2.4.1
 # Weird bug in latest version (0.17) of docutils; can remove once fixed
 docutils==0.16
 # Developers tools - code formatting
-cpplint
+cpplint==1.5.5
 black==20.8b1 
 # Developers tools - data generation scripts
 ase

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,16 +7,15 @@ matplotlib
 #qml
 # tqdm
 # for documentation
-sphinx>=2.1.2
-breathe>=4.14.1
+sphinx==4.0.1
+breathe==4.30.0
+jinja2==2.11.3
 sphinx_rtd_theme
-nbsphinx>=0.8.1
-pygments>=2.4.1
-# Weird bug in latest version (0.17) of docutils; can remove once fixed
-docutils==0.16
-# Developers tools - code formatting
+nbsphinx==0.8.5
+pygments==2.9.0
+docutils==0.17
 cpplint==1.5.5
-black==20.8b1 
+black==20.8b1
 # Developers tools - data generation scripts
 ase
 mpmath

--- a/tests/test_utils_sparsify.cc
+++ b/tests/test_utils_sparsify.cc
@@ -69,7 +69,7 @@ namespace rascal {
       BOOST_CHECK_EQUAL(dfps(i), v_dfps[i]);
     }
 
-    for (size_t i = 0; i < (size_t)ldmin2.size(); ++i) {
+    for (size_t i = 0; i < static_cast<size_t>(ldmin2.size()); ++i) {
       BOOST_CHECK_EQUAL(ldmin2(i), v_ldmin2[i]);
     }
   }


### PR DESCRIPTION
Fix two mostly unrelated issues, with the only commonality being that they were caused by upstream updates to dependencies.

Fix #356 - fix the offending line and pin down the cpplint version so we're not affected by future updates

Fix #355 - likewise, pin down some package versions to known working ones