### PR TITLE
Fix clang-format version parsing

### DIFF
--- a/cmake/clangformat.cmake
+++ b/cmake/clangformat.cmake
@@ -66,9 +66,9 @@ if(CLANG_FORMAT)
     add_custom_target(${CLANG_FORMAT_TARGET})
     set(CLANG_FORMAT_FOUND TRUE)
 else()
-  message(STATUS "The optional clang-format auto formatter has not been"
-    " found. For more information see"
-    " https://clang.llvm.org/docs/ClangFormat.html")
+    message(STATUS "The optional clang-format auto formatter has not been"
+                   " found. For more information see"
+                   " https://clang.llvm.org/docs/ClangFormat.html")
     set(CLANG_FORMAT_FOUND FALSE)
     return()
 endif()
@@ -77,9 +77,12 @@ execute_process(
     COMMAND ${CLANG_FORMAT} --version
     OUTPUT_VARIABLE CLANG_FORMAT_VERSION
 )
-string(REGEX REPLACE "clang-format version ([0-9.]+).*" "\\1" CLANG_FORMAT_VERSION "${CLANG_FORMAT_VERSION}")
+string(REGEX REPLACE ".*clang-format version ([0-9.]+).*" "\\1" CLANG_FORMAT_VERSION "${CLANG_FORMAT_VERSION}")
 if("${CLANG_FORMAT_VERSION}" VERSION_LESS "8.0")
-    message(FATAL_ERROR "Unsupported clang-format (version ${CLANG_FORMAT_VERSION}): a newer version (at least 8.0) is required")
+    message(STATUS "Unsupported clang-format (version ${CLANG_FORMAT_VERSION}): "
+                   "a more recent version (at least 8.0) is required")
+    set(CLANG_FORMAT_FOUND FALSE)
+    return()
 endif()
 
 # use clang-format to autoformat source code files DIR

--- a/cmake/clangformat.cmake
+++ b/cmake/clangformat.cmake
@@ -50,6 +50,8 @@
 # target to run cpplint.py for all configured sources
 set(CLANG_FORMAT_TARGET pretty-cpp)
 
+add_custom_target(${CLANG_FORMAT_TARGET})
+
 # project root directory
 set(CLANG_FORMAT_PROJECT_ROOT
   ${PROJECT_SOURCE_DIR} CACHE STRING "Project ROOT directory"
@@ -62,14 +64,21 @@ mark_as_advanced(CLANG_FORMAT)
 find_program(CLANG_FORMAT name clang-format HINTS $ENV/usr/bin)
 if(CLANG_FORMAT)
     message(STATUS "clang-format executable: ${CLANG_FORMAT}")
-    # common target to concatenate all cpplint.py targets
-    add_custom_target(${CLANG_FORMAT_TARGET})
     set(CLANG_FORMAT_FOUND TRUE)
 else()
-    message(STATUS "The optional clang-format auto formatter has not been"
-                   " found. For more information see"
-                   " https://clang.llvm.org/docs/ClangFormat.html")
+    set(ERROR_MESSAGE "clang-format not found, so the ${CLANG_FORMAT_TARGET} target is unavailable")
+    # send the error message at configure time
+    message(STATUS ${ERROR_MESSAGE})
     set(CLANG_FORMAT_FOUND FALSE)
+
+    # also send the error message whenever the user try to run `make pretty-cpp`
+    add_custom_target(clang-format-not-found
+        COMMAND ${CMAKE_COMMAND} -E echo "***ERROR*** ${ERROR_MESSAGE}"
+        # make sure to return a non zero status code so that make reports an error
+        COMMAND ${CMAKE_COMMAND} -E false
+    )
+    add_dependencies(${CLANG_FORMAT_TARGET} clang-format-not-found)
+
     return()
 endif()
 
@@ -79,9 +88,23 @@ execute_process(
 )
 string(REGEX REPLACE ".*clang-format version ([0-9.]+).*" "\\1" CLANG_FORMAT_VERSION "${CLANG_FORMAT_VERSION}")
 if("${CLANG_FORMAT_VERSION}" VERSION_LESS "8.0")
-    message(STATUS "Unsupported clang-format (version ${CLANG_FORMAT_VERSION}): "
-                   "a more recent version (at least 8.0) is required")
+    set(ERROR_MESSAGE
+        "Unsupported clang-format (version ${CLANG_FORMAT_VERSION}): "
+        "a more recent version (at least 8.0) is required."
+        "The ${CLANG_FORMAT_TARGET} target has been disabled."
+    )
+
+    # send the error message at configure time
+    message(STATUS ${ERROR_MESSAGE})
     set(CLANG_FORMAT_FOUND FALSE)
+
+    # also send the error message whenever the user try to run `make pretty-cpp`
+    add_custom_target(clang-format-too-old
+        COMMAND ${CMAKE_COMMAND} -E echo "***ERROR*** ${ERROR_MESSAGE}"
+        COMMAND ${CMAKE_COMMAND} -E false
+    )
+    add_dependencies(${CLANG_FORMAT_TARGET} clang-format-too-old)
+
     return()
 endif()
 


### PR DESCRIPTION
Ubuntu provides alternatives version with a different version string (Ubuntu clang-format version 11.0.0-2~ubuntu20.04.1)

Also downgrade the fatal error if the version do not match to a status message and disable `pretty-cpp`. This way users of the code have an easier time installing it.

----

Reported by @rosecers after the code failed to build in CI (https://github.com/cosmo-epfl/kernel-tutorials/runs/2711166252).