### PR TITLE
Fix gradients with optimal_basis GTOs

### DIFF
--- a/src/rascal/representations/calculator_spherical_expansion.hh
+++ b/src/rascal/representations/calculator_spherical_expansion.hh
@@ -1405,9 +1405,13 @@ namespace rascal {
       template <typename Coeffs>
       void finalize_coefficients(Coeffs & /*coefficients*/) {}
 
-      template <int NDims, typename Coeffs>
-      void
-      finalize_neighbour_derivative(Coeffs & /*coefficients_neigh_gradient*/) {}
+      /*
+       * Overwriting the finalization function to empty one, since the
+       * derivative of the spline is used
+       */
+      template <int NDims, typename Coeffs, typename Center>
+      void finalize_coefficients_der(Coeffs & /*coefficients_gradient*/,
+                                     Center & /*center*/) const {}
 
      protected:
       Matrix_Ref compute_neighbour_contribution(const double distance,


### PR DESCRIPTION
The finalize_gradients function was not overridden. Templates hell strikes again

Fix #364  

Rationale and detailed description of the changes:

Gradients were broken because orthonormalization was called on top of the spline pre-computation, due to a wrong override.

Tasks before review:

- [ ] Add tests, examples, and complete documentation of any added functionality
    - [ ] Make sure the autogenerated documentation appears in Sphinx and is
          formatted correctly (ask @max-veit if you need help with this task).
    - [ ] Write additional documentation in the Sphinx (not docstrings!) to
          explain the feature and its usage in plain English
    - [ ] Make sure the examples run (!) and produce the expected output
    - [ ] For bugfix pull requests, list here which tests have been added or re-enabled
          to verify the fix and catch future regressions as well as similar bugs
          elsewhere in the code.
- [ ] Run `make lint` on the project, ensure it passes
    - [ ] Run `make pretty-cpp` and `make pretty-python`, check that the
          auto-formatting is sensible
    - [ ] Review variable names, make sure they're descriptive (ask a friend)
    - [ ] Review all TODOs, convert to issues wherever possible
    - [ ] Make sure draft, in-progress, and commented-out code is moved to its
          own branch
- [ ] If committing any code in Jupyter/IPython notebooks, install and run `nbstripout`
- [ ] Merge with master and resolve any conflicts
- [ ] (anything else that's still in progress)

