### PR TITLE
Rascal json encoder

### DIFF
--- a/bindings/rascal/utils/__init__.py
+++ b/bindings/rascal/utils/__init__.py
@@ -6,6 +6,7 @@ from .io import (
     get_supported_io_versions,
     dump_obj,
     load_obj,
+    json_dumps_frame,
 )
 
 # Warning potential dependency loop: FPS imports models, which imports KRR,

--- a/bindings/rascal/utils/io.py
+++ b/bindings/rascal/utils/io.py
@@ -3,6 +3,7 @@ import importlib
 from collections import Iterable
 import numpy as np
 import json
+import datetime
 from copy import deepcopy
 from abc import ABC, abstractmethod
 
@@ -422,3 +423,55 @@ def _load_npy(data, path):
             if len(v) == 2:
                 if "npy" == v[0]:
                     data[k] = np.array(v[1])
+
+class RascalEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if hasattr(obj, 'todict'):
+            d = obj.todict()
+
+            if not isinstance(d, dict):
+                raise RuntimeError('todict() of {} returned object of type {} '
+                                   'but should have returned dict'
+                                   .format(obj, type(d)))
+            if hasattr(obj, 'ase_objtype'):
+                d['__ase_objtype__'] = obj.ase_objtype
+
+            return d
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        if isinstance(obj, np.integer):
+            return int(obj)
+        if isinstance(obj, np.bool_):
+            return bool(obj)
+        if isinstance(obj, datetime.datetime):
+            return {'__datetime__': obj.isoformat()}
+        if isinstance(obj, complex):
+            return {'__complex__': (obj.real, obj.imag)}
+        return json.JSONEncoder.default(self, obj)
+
+def json_dumps_frame(frames, **json_dumps_kwargs):
+    """Serialize frames to a JSON formatted string.
+
+    Parameters
+    ----------
+    frames : list(ase.Atoms) or ase.Atoms
+        List of atomic structures to be dumped to a json
+
+    json_dumps_kwargs : dict
+        List of arguments forwarded to json.dumps
+
+    Return
+    ------
+    T
+    """
+    if type(frames) is not list:
+        frames = [frames]
+
+    json_frames = {}
+    for i, frame in enumerate(frames):
+        json_frames[str(i)] = json.loads(json.dumps(frame, cls=RascalEncoder))
+
+    json_frames['ids'] = list(range(len(frames)))
+    json_frames['nextid'] = len(frames)
+
+    return json.dumps(json_frames, **json_dumps_kwargs)

--- a/tests/python/python_binding_tests.py
+++ b/tests/python/python_binding_tests.py
@@ -17,7 +17,11 @@ from python_representation_calculator_test import (
 from python_models_test import TestNumericalKernelGradient, TestCosineKernel
 from python_math_test import TestMath
 from python_test_sparsify_fps import TestFPS
-from python_utils_test import TestOptimalRadialBasis
+from python_utils_test import (
+        TestOptimalRadialBasis,
+        TestIO
+)
+
 from md_calculator_test import TestGenericMD
 
 

--- a/tests/python/python_utils_test.py
+++ b/tests/python/python_utils_test.py
@@ -7,17 +7,23 @@ from rascal.utils import (
     get_radial_basis_pca,
     get_radial_basis_projections,
     get_optimal_radial_basis_hypers,
+    json_dumps_frame
 )
+from rascal.lib import neighbour_list
+from rascal.neighbourlist import base
 
 from test_utils import load_json_frame, BoxList, Box, dot
+import tempfile
 import unittest
 import numpy as np
 import sys
 import os
 import json
+import tempfile
 from copy import copy, deepcopy
 from scipy.stats import ortho_group
 import pickle
+import ase.io
 
 rascal_reference_path = "reference_data"
 inputs_path = os.path.join(rascal_reference_path, "inputs")
@@ -91,3 +97,38 @@ class TestOptimalRadialBasis(unittest.TestCase):
         soap_feats_2 = soap_opt_2.transform(self.frames).get_features(soap_opt_2)
 
         self.assertTrue(np.allclose(soap_feats, soap_feats_2))
+
+class TestIO(unittest.TestCase):
+    def setUp(self):
+        self.fns = [
+            os.path.join(inputs_path, "CaCrP2O7_mvc-11955_symmetrized.json"),
+            os.path.join(inputs_path, "SiC_moissanite_supercell.json"),
+            os.path.join(inputs_path, "methane.json"),
+        ]
+
+    def test_dumps_frame(self):
+        """
+        Checks if json file decoded by RascalEncoder in dumps_frame can be read
+        by rascal
+        """
+        nl_options = [
+            dict(name="centers", args=dict()),
+            dict(name="neighbourlist", args=dict(cutoff=3)),
+            dict(name="centercontribution", args=dict()),
+            dict(name="strict", args=dict(cutoff=3)),
+        ]
+        managers = base.StructureCollectionFactory(nl_options)
+        for fn in self.fns:
+            frame = ase.io.read(fn)
+            dumped_json = json_dumps_frame(frame)
+            tmp = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+            tmp.write(dumped_json)
+            try:
+                managers.add_structures(tmp.name)
+                tmp.close()
+                os.unlink(tmp.name)
+            except:
+                tmp.close()
+                os.unlink(tmp.name)
+
+


### PR DESCRIPTION
Implements a rascal json encoder from ase frames to a json readable by rascal (more important for the c++ side than python). Solves issue #363 

TODO:
- add doc in the doc page how to use this
- polish python doc of json_dumps_frame

Tasks before review:

- [ ] Add tests, examples, and complete documentation of any added functionality
    - [ ] Make sure the autogenerated documentation appears in Sphinx and is
          formatted correctly (ask @max-veit if you need help with this task).
    - [ ] Write additional documentation in the Sphinx (not docstrings!) to
          explain the feature and its usage in plain English
    - [ ] Make sure the examples run (!) and produce the expected output
    - [ ] For bugfix pull requests, list here which tests have been added or re-enabled
          to verify the fix and catch future regressions as well as similar bugs
          elsewhere in the code.
- [ ] Run `make lint` on the project, ensure it passes
    - [ ] Run `make pretty-cpp` and `make pretty-python`, check that the
          auto-formatting is sensible
    - [ ] Review variable names, make sure they're descriptive (ask a friend)
    - [ ] Review all TODOs, convert to issues wherever possible
    - [ ] Make sure draft, in-progress, and commented-out code is moved to its
          own branch
- [ ] If committing any code in Jupyter/IPython notebooks, install and run `nbstripout`
- [ ] Merge with master and resolve any conflicts
- [ ] (anything else that's still in progress)


Remaining tasks, out of scope of this pull request: (optional)


-
-
- [ ] Make sure to add these points to the issues or to the meeting agenda so they don't
get forgotten!

