### PR TITLE
Spherical harmonics sanitation

### DIFF
--- a/src/rascal/math/spherical_harmonics.hh
+++ b/src/rascal/math/spherical_harmonics.hh
@@ -46,11 +46,11 @@ namespace rascal {
      * \f{equation}{
      * Y_\ell^m(\theta, \phi) =
      * \begin{cases}
-     * \sqrt{\frac{2\ell + 1}{2\pi} \frac{(\ell + m)!}{(\ell - m)!}}
-     *      P_\ell^{-m}(\cos\theta) \sin(-m\phi) & \text{for } m < 0\\
+     * (-1)^m \sqrt{\frac{2\ell + 1}{2\pi} \frac{(\ell + m)!}{(\ell - m)!}}
+     *      P_\ell^{-m}(\cos\theta) \sin(|m|\phi) & \text{for } m < 0\\
      * \sqrt{\frac{2\ell + 1}{4\pi}} P_\ell(\cos\theta) & \text{for } m = 0\\
-     * \sqrt{\frac{2\ell + 1}{2\pi} \frac{(\ell - m)!}{(\ell + m)!}}
-     *      P_\ell^{m}(\cos\theta) \cos(m\phi) & \text{for } m > 0
+     * (-1)^m \sqrt{\frac{2\ell + 1}{2\pi} \frac{(\ell - m)!}{(\ell + m)!}}
+     *      P_\ell^{m}(\cos\theta) \cos(|m|\phi) & \text{for } m > 0
      * \end{cases}
      * \f}
      *


### PR DESCRIPTION
Wishfully modified the header description. Now must change code without burning down the house

PR to fix the phase factors in the spherical harmonics, and to 

Fix #346 

Rationale and detailed description of the changes:
The current SPH implementation uses a non-standard (non-wikipedia ^_^) phase convention. 
This leads to all sorts of downstream pain when dealing with combining real-valued coefficients.
The idea is to fix this for good and add a few examples explaining clearly how to manipulate these coefficients.

Tasks before review:

- [ ] Add tests, examples, and complete documentation of any added functionality
    - [ ] Make sure the autogenerated documentation appears in Sphinx and is
          formatted correctly (ask @max-veit if you need help with this task).
    - [ ] Write additional documentation in the Sphinx (not docstrings!) to
          explain the feature and its usage in plain English
    - [ ] Make sure the examples run (!) and produce the expected output
    - [ ] For bugfix pull requests, list here which tests have been added or re-enabled
          to verify the fix and catch future regressions as well as similar bugs
          elsewhere in the code.
- [ ] Run `make lint` on the project, ensure it passes
    - [ ] Run `make pretty-cpp` and `make pretty-python`, check that the
          auto-formatting is sensible
    - [ ] Review variable names, make sure they're descriptive (ask a friend)
    - [ ] Review all TODOs, convert to issues wherever possible
    - [ ] Make sure draft, in-progress, and commented-out code is moved to its
          own branch
- [ ] If committing any code in Jupyter/IPython notebooks, install and run `nbstripout`
- [ ] Merge with master and resolve any conflicts
- [ ] (anything else that's still in progress)


Remaining tasks, out of scope of this pull request: (optional)


-
-
- [ ] Make sure to add these points to the issues or to the meeting agenda so they don't
get forgotten!

