### PR TITLE
Fix incorrect stress symmetrization in generic MD driver

### DIFF
--- a/bindings/rascal/models/genericmd.py
+++ b/bindings/rascal/models/genericmd.py
@@ -126,5 +126,5 @@ class GenericMDCalculator:
         stress_matrix = np.zeros((3, 3))
         stress_matrix[tuple(zip(*self.matrix_indices_in_voigt_notation))] = stress_voigt
         # Symmetrize the stress matrix (replicate upper-diagonal entries)
-        stress_matrix += np.triu(stress_matrix).T
+        stress_matrix += np.triu(stress_matrix, k=1).T
         return energy, forces, stress_matrix


### PR DESCRIPTION
Tiny fix for a small error with (potentially) big consequences

Fix #372 

- [ ] Add tests, examples, and complete documentation of any added functionality
    - [ ] Make sure the autogenerated documentation appears in Sphinx and is
          formatted correctly (ask @max-veit if you need help with this task).
    - [ ] Write additional documentation in the Sphinx (not docstrings!) to
          explain the feature and its usage in plain English
    - [ ] Make sure the examples run (!) and produce the expected output
    - [ ] For bugfix pull requests, list here which tests have been added or re-enabled
          to verify the fix and catch future regressions as well as similar bugs
          elsewhere in the code.
        - [ ] Not sure about this one - what we _should_ have tested is that we can run NpT-MD with i-PI where the conserved quantity does indeed remain conserved. But that's hard to automate.
- [x] Run `make lint` on the project, ensure it passes
    - [x] Run `make pretty-cpp` and `make pretty-python`, check that the
          auto-formatting is sensible
    - [x] Review variable names, make sure they're descriptive (ask a friend)
    - [x] Review all TODOs, convert to issues wherever possible
    - [x] Make sure draft, in-progress, and commented-out code is moved to its
          own branch
- [x] Merge with master and resolve any conflicts

