### PR TITLE
Don't mention unimplemented features in the documentation

### DIFF
--- a/bindings/rascal/representations/spherical_covariants.py
+++ b/bindings/rascal/representations/spherical_covariants.py
@@ -32,8 +32,7 @@ class SphericalCovariants(BaseIO):
 
     gaussian_sigma_type : str
         How the Gaussian atom sigmas (smearing widths) are allowed to
-        vary -- fixed ('Constant'), by species ('PerSpecies'), or by
-        distance from the central atom ('Radial').
+        vary. Only fixed smearing width ('Constant') are implemented.
 
     gaussian_sigma_constant : float
         Specifies the atomic Gaussian widths, in the case where they're

--- a/bindings/rascal/representations/spherical_expansion.py
+++ b/bindings/rascal/representations/spherical_expansion.py
@@ -32,8 +32,7 @@ class SphericalExpansion(BaseIO):
 
     gaussian_sigma_type : str
         How the Gaussian atom sigmas (smearing widths) are allowed to
-        vary -- fixed ('Constant'), by species ('PerSpecies'), or by
-        distance from the central atom ('Radial').
+        vary. Only fixed smearing width ('Constant') are implemented.
 
     gaussian_sigma_constant : float
         Specifies the atomic Gaussian widths, in the case where they're

--- a/bindings/rascal/representations/spherical_invariants.py
+++ b/bindings/rascal/representations/spherical_invariants.py
@@ -48,8 +48,7 @@ class SphericalInvariants(BaseIO):
 
     gaussian_sigma_type : str
         How the Gaussian atom sigmas (smearing widths) are allowed to
-        vary -- fixed ('Constant'), by species ('PerSpecies'), or by
-        distance from the central atom ('Radial').
+        vary. Only fixed smearing width ('Constant') are implemented.
 
     gaussian_sigma_constant : float
         Specifies the atomic Gaussian widths, in the case where they're


### PR DESCRIPTION
The Python documentation mentions `gaussian_sigma_type` "PerSpecies" and "Radial", but none of these options are implemented, which is very confusing.

@rosecers just wasted 30 min re-building librascal to try to make this work since it was documented. Overall, it is very poor practice to put non-supported features in the documentation without any sign that they’re not supported.

Does anyone knows of another "desired" feature which is documented but not implemented? I would also remove the corresponding doc.