### PR TITLE
Feat/kvec generator

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,7 @@ set(RASCAL_SOURCES
     rascal/math/interpolator.cc
     rascal/math/gauss_legendre.cc
     rascal/math/spherical_harmonics.cc
-
+    rascal/math/kvec_generator.cc
     rascal/structure_managers/structure_manager_lammps.cc
     rascal/structure_managers/structure_manager_centers.cc
     rascal/representations/calculator_base.cc

--- a/src/rascal/math/kvec_generator.cc
+++ b/src/rascal/math/kvec_generator.cc
@@ -1,0 +1,241 @@
+/**
+ * @file   kvec_generator.cc
+ *
+ * @author  Andrea Grisafi <andrea.grisafi@epfl.ch>
+ * @author  Kevin Kazuki Huguenin-Dumittan <kevin.huguenin-dumittan@epfl.ch>
+ *
+ * @date   10 February 2021
+ *
+ * @brief Generate the k-vectors (also called reciprocal or Fourier vectors)
+ *        needed for the k-space implementation of LODE and SOAP.
+ *        More specifically, these are all points of a (reciprocal space)
+ *        lattice that lie within a ball of a specified cutoff radius.
+ *
+ * Copyright  2021  Andrea Grisafi, Kevin Kazuki Huguenin-Dumittan, COSMO(EPFL)
+ *
+ * Rascal is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3, or (at
+ * your option) any later version.
+ *
+ * Rascal is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; see the file LICENSE. If not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "rascal/math/kvec_generator.hh"
+
+#include <assert.h>
+
+using namespace rascal::math;  // NOLINT
+
+/** Function for finding and storing all reciprocal space vectors
+ * of a lattice whose length is smaller than a cutoff.
+ * INPUTS
+ * - basisvecs[3][3]: 3x3 matrix containing the three basis
+ *   vectors b1, b2, b3 of a 3D lattice, stored in the format
+ *   b1 = basisvecs[0], b2=basisvecs[1] etc.
+ *   a general vector in the lattice will then be of the form
+ *   k = n1*b1 + n2*b2 + n3*b3, where n1,n2,n3 are integers
+ * - kcut: length of the cutoff
+ *
+ * OUTPUTS
+ * Computes half of the lattice points k excluding the origin lying in
+ * a ball of radius kcut, where pairs related by k1 = -k2 are only included
+ * once. Mathematically, these are the vectors s.t. norm(k) <= kcut.
+ * More specifically, all k-vectors within the ball are selected which are
+ * lying in the b1-direction from the plane spanned by b2 and b3.
+ *
+ * DESCRIPTION OF ALGORITHM
+ * Essentially, we find the vectors by performing a brute force search of
+ * all vectors contained in a box. The first part of the code is used to
+ * determine the optimal geometry of this box, while the second part loops
+ * over all vectors within the box.
+ *
+ * The key idea is that a k-vector is parametrized by three integers via
+ * k = n1*b1 + n2*b2 + n3*b3. Using these integers, and the Einstein summation
+ * convention, we can write the squared norm of k as:
+ * k*k = M_ij n_i n_j, where M_ij is the 3x3 matrix M_ij = b_i * b_j.
+ * The rest of the algorithm is performed directly in this index-space, i.e.
+ * the space of (n1, n2, n3).
+ *
+ * In the brute force part, we would then like to loop over all possible
+ * values of (n1, n2, n3), where 0<n1<n1max, |n2|<n2max and |n3|<n3max
+ * to ensure that only half of the points are found (+ some corrections
+ * along the boundary n1=0, as described below before the loop starts) for
+ * some n1max, n2max and n3max.
+ *
+ * The preparation part is used to determine the values of njmax that are
+ * optimal, i.e. contains the smallest amount of redundancy. We can calculate
+ * this analytically in the following way:
+ * To get the bounds for n1, fix the value of n1 and consider the restriction
+ * of the bilinear form M_ij n_i n_j onto the subspace spanned by (n2, n3).
+ * The equation k*k = M_ij n_i n_j can then be recast into the form:
+ * k*k + (constant part depending on n1) = quadratic form in (n2, n3).
+ * For a solution to exist, the left hand side of this equation has to be
+ * positive, which provides us with an inequality that results in a bound
+ * for n1, namely n1max. Similarly, we obtain n2max and n3max.
+ */
+Kvectors::Kvectors(double cutoff, Eigen::Matrix3d basisvectors,
+                   bool is_reciprocal_cell, bool need_origin) {
+  // INITIALIZATION
+  // Set internal variables apart from cell
+  this->kcutoff = cutoff;
+  this->include_origin = need_origin;
+
+  /* Store provided basis vectors into the internal variable basisvecs.
+   * We need to distinguish whether the provided vectors are already
+   * reciprocal cell vectors or need to be converted first
+   */
+  if (not is_reciprocal_cell) {  // real space cell is given
+    // Create reciprocal cell from real space cell
+    Eigen::Matrix3d tcell = basisvectors.transpose();
+    this->basisvecs = 2.0 * math::PI * tcell.inverse();
+  } else {  // cell of reciprocal space is already given
+    this->basisvecs = basisvectors;
+  }
+
+  /* PREPARATION: DEFINE SEARCH SPACE BOX
+   * Determine the optimal bounds n1max, n2max, n3max that
+   * define the search space box. Roughly speaking, our
+   * goal will then be to find all vectors
+   * k = n1*b1 + n2*b2 + n3*b3,
+   * where |n1|<n1max, |n2|<n2max etc., whose norm is
+   * smaller than kcut. In practice, only half of the
+   * k-vectors are returned up to the identification
+   * k2 = -k1, since such pairs can be grouped together in
+   * the remaining part.
+   */
+  // Define some const shortcuts for quantities that shouldn't change
+  // during the precomputation step
+  const Eigen::Matrix3d bvecs = this->basisvecs;
+  const double kcut = this->kcutoff;
+
+  // Generate inner product matrix M_ij = b_i * b_j and the volume of
+  // a cell in reciprocal space to compute the bounds of the optimal
+  // search space box
+  const Matrix_t M = bvecs * bvecs.transpose();
+  const double kcell_vol = basisvecs.determinant();
+  const size_t n1max =
+      floor(sqrt(M(1, 1) * M(2, 2) - M(1, 2) * M(1, 2)) / kcell_vol * kcut);
+  const size_t n2max =
+      floor(sqrt(M(0, 0) * M(2, 2) - M(0, 2) * M(0, 2)) / kcell_vol * kcut);
+  const size_t n3max =
+      floor(sqrt(M(0, 0) * M(1, 1) - M(0, 1) * M(0, 1)) / kcell_vol * kcut);
+
+  // Total number of points that will be checked (used for initialization)
+  size_t numvectors_searchbox = n3max + n2max * (2 * n3max + 1) +
+                                n1max * (2 * n2max + 1) * (2 * n3max + 1);
+  // Add origin if needed
+  if (this->include_origin) {
+    numvectors_searchbox += 1;
+  }
+
+  /* Auxiliary variables: using the squared norm rather than norm itself is
+   * computationally more efficient. Use one variable each for the squared
+   * cutoff and the squared norm of the k-vectors (to be updated during search)
+   */
+  const double kcutsq = kcut * kcut;
+  double normsq;
+
+  // Store basis vectors for increased readability
+  // and ease of use
+  const Eigen::RowVector3d b1 = basisvecs.row(0);
+  const Eigen::RowVector3d b2 = basisvecs.row(1);
+  const Eigen::RowVector3d b3 = basisvecs.row(2);
+
+  // Initialize current vector and number of found vectors
+  size_t numvectors = 0;
+  Eigen::RowVector3d kvec_new(0, 0, 0);
+
+  // Initialize arrays in which to store results
+  kvectors.resize(numvectors_searchbox, 3);
+  kvector_norms.resize(numvectors_searchbox);
+
+  /* START OF MAIN PART
+   * Begin loops to find the points within the search box
+   * contained in the ball. In order to avoid double counting
+   * pairs of points related by k2=-k1, the loops are chosen
+   * carefully, and separated into parts dealing with the cases
+   * - n1>0
+   * - n1=0, n2>0
+   * - n1=0, n2=0, n3>0
+   *  in reverse order (order of increasing complexity of code)
+   */
+
+  // Step 0: If desired (e.g. for SOAP), include origin:
+  if (this->include_origin) {
+    kvectors.row(0) = kvec_new;
+    kvector_norms(0) = 0.;
+    numvectors += 1;
+  }
+
+  // Step 1: Find all points of the form (0, 0, n3>0)
+  for (size_t n3 = 1; n3 <= n3max; ++n3) {
+    // Update the current vector
+    kvec_new += b3;
+    normsq = kvec_new.dot(kvec_new);
+
+    // If vector is inside ball, add it
+    if (normsq <= kcutsq) {
+      kvectors.row(numvectors) = kvec_new;
+      kvector_norms(numvectors) = sqrt(normsq);
+      numvectors += 1;
+    }  // end if
+  }    // end loop over n3
+
+  // Step 2: Find all points of the form (0, n2>0, n3)
+  for (size_t n2 = 1; n2 <= n2max; ++n2) {
+    // Update current vector for new n2 value
+    // We subtract (n3max+1)*b3 s.t. we only have to add b3
+    // at each iteration to get the correct vector
+    kvec_new = n2 * b2 - (n3max + 1) * b3;
+
+    for (size_t n3 = 0; n3 < 2 * n3max + 1; ++n3) {
+      // Update the current vector
+      kvec_new += b3;
+      normsq = kvec_new.dot(kvec_new);
+
+      // If vector is inside ball, add it
+      if (normsq <= kcutsq) {
+        kvectors.row(numvectors) = kvec_new;
+        kvector_norms(numvectors) = sqrt(normsq);
+        numvectors += 1;
+      }  // end if
+    }    // end loop over n3
+  }      // end loop over n2
+
+  // Step 3: Find all remaining points of the form (n1>0, n2, n3)
+  for (size_t n1 = 1; n1 <= n1max; ++n1) {
+    for (size_t n2 = 0; n2 < 2 * n2max + 1; ++n2) {
+      // Update current vector for new n2 value
+      // We subtract (n3max+1)*b3 s.t. we only have to add b3
+      // at each iteration to get the desired vector
+      kvec_new = n1 * b1 + n2 * b2 - n2max * b2 - (n3max + 1) * b3;
+
+      for (size_t n3 = 0; n3 < 2 * n3max + 1; ++n3) {
+        // Update the current vector
+        kvec_new += b3;
+        normsq = kvec_new.dot(kvec_new);
+
+        // If vector is inside ball, add it
+        if (normsq <= kcutsq) {
+          kvectors.row(numvectors) = kvec_new;
+          kvector_norms(numvectors) = sqrt(normsq);
+          numvectors += 1;
+        }  // end if
+      }    // end loop over n3
+    }      // end loop over n2
+  }        // end loop over n1
+
+  // Final adjustments: Get rid of the empty components
+  assert(numvectors != 0);
+  kvectors.conservativeResize(numvectors, 3);
+  kvector_norms.conservativeResize(numvectors);
+}

--- a/src/rascal/math/kvec_generator.hh
+++ b/src/rascal/math/kvec_generator.hh
@@ -1,0 +1,137 @@
+/**
+ * @file   kvec_generator.cc
+ *
+ * @author  Andrea Grisafi <andrea.grisafi@epfl.ch>
+ * @author  Kevin Kazuki Huguenin-Dumittan <kevin.huguenin-dumittan@epfl.ch>
+ *
+ * @date   10 February 2021
+ *
+ * @brief Generate the k-vectors (also called reciprocal or Fourier vectors)
+ *        needed for the k-space implementation of LODE and SOAP.
+ *        More specifically, these are all points of a (reciprocal space)
+ *        lattice that lie within a ball of a specified cutoff radius.
+ *
+ * Copyright  2021  Andrea Grisafi, Kevin Kazuki Huguenin-Dumittan, COSMO(EPFL)
+ *
+ * Rascal is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3, or (at
+ * your option) any later version.
+ *
+ * Rascal is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; see the file LICENSE. If not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#ifndef SRC_RASCAL_MATH_KVEC_GENERATOR_HH_
+#define SRC_RASCAL_MATH_KVEC_GENERATOR_HH_
+
+#include "rascal/math/utils.hh"
+
+#include <Eigen/Dense>
+
+namespace rascal {
+  namespace math {
+    /**
+     * Produce the k-vectors (also called reciprocal space or Fourier
+     * vectors) needed for the k-space implementation of LODE and SOAP.
+     *
+     * More specifically, if b1, b2 and b3 are basis vectors of a reciprocal
+     * lattice, this class is used to get all vectors of the form:
+     * \f{equation}{k = n_1b_1 + n_2b_2 + n_3b_3,\f}
+     * where n1,n2,n3 are integers, which are inside a ball of a given
+     * cutoff radius \f$k_\mathrm{cut}\f$.
+     *
+     * Note that for any radius > 0, the origin \f$k=(0,0,0)\f$ is always
+     * in the ball and is the first entry of the returned vectors.
+     * For applications where k=0 should be excluded, there is the option
+     * to do so.
+     * For any other k-vector k, symmetry typically allows us to group the
+     * two vectors k and -k together. Thus, only one out of each such pair
+     * is returned as a representant.
+     *
+     */
+    class Kvectors {
+     private:
+      /* Store the quantities provided by the user that completely determine
+       * the problem:
+       * The first two quantities, the cutoff radius in reciprocal space as
+       * well as the three basis vectors of the reciprocal cell, determine
+       * the geometry, and thus are most important.
+       * The optional parameter include_origin is stored as well which
+       * determines whether the point (0,0,0) should be included or not.
+       */
+      double kcutoff{};
+      Eigen::Matrix3d basisvecs{};
+      bool include_origin{};
+
+      /* Variables for quantities that can be returned by this class:
+       * - the N x 3 Eigen matrix containing the k-vectors in the ball
+       * - the Eigen vector of size N containing the norms of the k-vectors
+       */
+      Matrix_t kvectors{};
+      Vector_t kvector_norms{};
+
+     public:
+      /** Constructor:
+       * Upon initialization, directly compute all the k-vectors on the
+       * lattice specified by three basisvectors lying within a ball.
+       * @param cutoff Cutoff radius of reciprocal space ball.
+       *     As a guideline, if the smearing parameter of the density
+       *     is given by \f$sigma\f$, use \f$pi/sigma\f$ as cutoff.
+       * @param basisvectors 3x3 matrix containing the three basis
+       *     vectors a1, a2, a3 of the real space unit cell, stored as:
+       *     a1 = basisvectors[0], a2=basisvectors[1], etc.
+       *     These are then automatically converted to the corresponding
+       *     reciprocal cell vectors b1, b2, b3 by the formulae:
+       *     \f{equation}{b_1 = 2\pi \frac{a_1 \times a_2}
+       *                 {a_1 \cdot (a_2 \times a_3)} \f}
+       *     and similarly for the periodic permutations.
+       *     It is also possible to provide the basis vectors of the
+       *     reciprocal lattice directly by using the option below.
+       * @param is_reciprocal_cell false by default.
+       *     If set to true, it indicates that the cell provided
+       *     in the variable basisvectors is already the reciprocal cell.
+       *     Thus, the formula above for converting the a_i's to the b_i's
+       *     is not used, and the provided cell is used directly.
+       * @param need_origin false by default.
+       *     If set to true, the list of found k-vectors will also
+       *     contain the origin k=(0,0,0), which will then be stored
+       *     as the very first element in the matrix of found vectors.
+       */
+      Kvectors(double cutoff, Eigen::Matrix3d basisvectors,
+               bool is_reciprocal_cell = false, bool need_origin = false);
+
+      /** Returns number of vectors found within cutoff radius
+       * without double counting pairs related by inversion.
+       * This is the actual number that can be used to iterate over all
+       * vectors and its norms obtained from get_kvectors and get_norms.
+       */
+      size_t get_numvectors() const { return this->kvector_norms.size(); }
+
+      /** Returns reference to the Eigen matrix containing all
+       * k-vectors within cutoff radius without double counting, where
+       * row(i) = i-th vector. If the origin k=(0,0,0) is included, it is
+       * always stored in row(0).
+       */
+      Eigen::Ref<Matrix_t> get_kvectors() {
+        return Eigen::Ref<Matrix_t>(this->kvectors);
+      }
+
+      /** Returns const reference to the Eigen vector containing the norm
+       * of all k-vectors within the cutoff without double counting.
+       */
+      Eigen::Ref<const Vector_t> const get_kvector_norms() {
+        return Eigen::Ref<const Vector_t>(this->kvector_norms);
+      }
+    };  // Kvectors class
+  }     // namespace math
+}  // namespace rascal
+
+#endif  // SRC_RASCAL_MATH_KVEC_GENERATOR_HH_

--- a/tests/test_math.hh
+++ b/tests/test_math.hh
@@ -458,6 +458,49 @@ namespace rascal {
     }    // for (auto inputs...) (function inputs)
   }
 
+  /**
+   * @brief Fixture used for testing kvecgenerator
+   *
+   * Multiple cells are defined that cover a range of relevant
+   * structures from the simple cubic structure having highest
+   * symmetry to triclinic cells whose extension along the three
+   * basis vectors is very different.
+   * The tests are then run over all these structures to ensure
+   * that the kvecgenerator works properly under various conditions.
+   */
+  struct KvecgenRefFixture {
+    KvecgenRefFixture() {
+      // Define basic cell quantities
+      Eigen::Matrix3d cell{};
+      double a = 10.;
+      double c = std::sqrt(8. / 3.) * a;
+
+      // Cells 1 and 2: Simple cubic cells of different dimensions
+      cell << 1., 0., 0., 0., 1., 0., 0., 0., 1.;
+      this->cells.push_back(a * cell);
+      this->cells.push_back(1.5 * a * cell);
+
+      // Cell 3: hcp cell (taken from test_structure.hh)
+      cell << a, -0.5 * a, 0., 0., std::sqrt(3.) / 2. * a, 0., 0., 0., c;
+      this->cells.push_back(cell);
+
+      // Cell 4: fcc cell (taken from test_structure.hh)
+      cell << a, 0.5 * a, 0.5 * a, 0., 0.5 * a, 0., 0., 0., 0.5 * a;
+      this->cells.push_back(cell);
+
+      // Cells 5 and 6: Two triclinic cells including high asymmetry
+      cell << 1., 0.3, 0.2, 0.4, 1., -0.1, 0., 0.3, 1.;
+      this->cells.push_back(a * cell);
+      cell << 0.8, 0.3, 0.2, 0.1, 3., -0.2, 0., 0.3, 0.7;
+      this->cells.push_back(a * cell);
+    }
+
+    ~KvecgenRefFixture() = default;
+
+    // Variable to store generated cells
+    std::vector<Eigen::Matrix3d> cells{};
+  };
+
   struct Hyp1F1RefFixture {
     Hyp1F1RefFixture() {
       this->ref_data =

--- a/tests/test_math_kvecgenerator.cc
+++ b/tests/test_math_kvecgenerator.cc
@@ -1,0 +1,337 @@
+/**
+ * @file   test_kvecgenerator.cc
+ *
+ * @author Kevin Kazuki Huguenin-Dumittan <kevin.huguenin-dumittan@epfl.ch>
+ *
+ * @date   2021
+ *
+ * @brief Test the class used to generate the k-vectors, also called
+ *        reciprocal space vectors, used in the k-space implementation
+ *        of the spherical expansion coefficients of SOAP and LODE
+ *
+ * Copyright  2019  Felix Musil, COSMO (EPFL), LAMMM (EPFL)
+ *
+ * Rascal is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3, or (at
+ * your option) any later version.
+ *
+ * Rascal is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; see the file LICENSE. If not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "test_math.hh"
+
+#include "rascal/math/kvec_generator.hh"
+
+#include <boost/test/unit_test.hpp>
+
+#include <Eigen/Eigenvalues>
+
+#include <cmath>
+
+namespace rascal {
+
+  BOOST_AUTO_TEST_SUITE(test_kvecgenerator);
+
+  /* ---------------------------------------------------------------------- */
+  /**
+   * Test that the kvecgenerator produces the desired vectors for small
+   * cells, where we can explicitly list the correct vectors
+   */
+  BOOST_AUTO_TEST_CASE(kvecgen_smallcells_test) {
+    // Define reciprocal space cell to be used in the following tests
+    // We use the identity matrix to avoid floating point errors
+    Eigen::Matrix3d reciprocal_cell;
+    reciprocal_cell << 1, 0, 0, 0, 1, 0, 0, 0, 1;
+
+    // Store vectors that should be found, if the code runs correctly
+    Eigen::RowVector3d v100, v010, v001, v110, v101, v011, v01m, v10m, v1m0,
+        v111, v11m, v1m1, v1mm;
+    v100 << 1, 0, 0;
+    v010 << 0, 1, 0;
+    v001 << 0, 0, 1;
+    v110 << 1, 1, 0;
+    v101 << 1, 0, 1;
+    v011 << 0, 1, 1;
+    v01m << 0, 1, -1;
+    v10m << 1, 0, -1;
+    v1m0 << 1, -1, 0;
+    v111 << 1, 1, 1;
+    v11m << 1, 1, -1;
+    v1m1 << 1, -1, 1;
+    v1mm << 1, -1, -1;
+
+    // For small enough cutoff radii, namely for the intervals
+    // [1,sqrt(2)), [sqrt(2), sqrt(3)), [sqrt(3),2) we can explicitly
+    // list all vector that should be found by the algorithm.
+    // Store these solutions in the correct order for each cutoff
+    Eigen::MatrixXd kvec_expected_0(3, 3);
+    kvec_expected_0 << v001, v010, v100;
+
+    Eigen::MatrixXd kvec_expected_1(9, 3);
+    kvec_expected_1 << v001, v01m, v010, v011, v1m0, v10m, v100, v101, v110;
+
+    Eigen::MatrixXd kvec_expected_2(13, 3);
+    kvec_expected_2 << v001, v01m, v010, v011, v1mm, v1m0, v1m1, v10m, v100,
+        v101, v11m, v110, v111;
+
+    Eigen::MatrixXd * kvecs_expected[3] = {&kvec_expected_0, &kvec_expected_1,
+                                           &kvec_expected_2};
+
+    // For various cutoff radii close to the thresholds after which
+    // we would get further vectors, we compare the obtained vectors
+    // to the correct solution. The variable i runs over the three intervals
+    double cutoff_lims[4] = {1., math::SQRT_TWO, math::SQRT_THREE, 2.};
+    double cutoff_eps = 1e-12;
+    for (int i = 0; i < 3; i++) {
+      math::Kvectors k_vectors_min(cutoff_lims[i] + cutoff_eps, reciprocal_cell,
+                                   true);
+      BOOST_CHECK_EQUAL(k_vectors_min.get_kvectors(), *kvecs_expected[i]);
+      math::Kvectors k_vectors_max(cutoff_lims[i + 1] - cutoff_eps,
+                                   reciprocal_cell, true);
+      BOOST_CHECK_EQUAL(k_vectors_max.get_kvectors(), *kvecs_expected[i]);
+    }
+
+    // Check whether the code also works if we use a different, highly
+    // distorted basis to describe the same lattice
+    Eigen::Matrix3d cell_distorted_basis;
+    cell_distorted_basis << 1, 0, 0, 5, 1, 0, 5, 5, 1;
+
+    // Define the vectors that should be obtained from this procedure
+    // Note that the obtained vectors should be the same as for the
+    // undistorted lattice, but their order and representant out of
+    // +k and -k will be different
+    Eigen::MatrixXd kvec_expected_3(3, 3), kvec_expected_4(9, 3);
+    kvec_expected_3 << v100, -v010, v001;
+    kvec_expected_4 << v100, -v110, -v010, v1m0, v011, -v10m, v001, v101, -v01m;
+    Eigen::MatrixXd * kvecs_distorted[2] = {&kvec_expected_3, &kvec_expected_4};
+
+    // Run the algorithm and compare the obtained k-vectors to the
+    // correct ones
+    for (int i = 0; i < 2; i++) {
+      math::Kvectors k_vectors_min(cutoff_lims[i] + cutoff_eps,
+                                   cell_distorted_basis, true);
+      BOOST_CHECK_EQUAL(k_vectors_min.get_kvectors(), *kvecs_distorted[i]);
+      math::Kvectors k_vectors_max(cutoff_lims[i + 1] - cutoff_eps,
+                                   cell_distorted_basis, true);
+      BOOST_CHECK_EQUAL(k_vectors_max.get_kvectors(), *kvecs_distorted[i]);
+    }
+  }  // end test case
+
+  /* ---------------------------------------------------------------------- */
+  /**
+   * @brief Check that all obtained k-vectors lie inside the ball
+   * and that the norms computed by the kvecgenerator are correct.
+   */
+  BOOST_FIXTURE_TEST_CASE(kvecgen_allvecs_in_ball_test, KvecgenRefFixture) {
+    // For each cell: get the required quantities for the tests
+    double cutoff = 6.28;
+    for (auto & cell : this->cells) {
+      math::Kvectors kvectors(cutoff, cell);
+      int nvec = kvectors.get_numvectors();
+      auto kvecs = kvectors.get_kvectors();
+      auto kvals = kvectors.get_kvector_norms();
+
+      // Start checking the obtained norms
+      double cutoffsq = cutoff * cutoff;
+      for (int i = 0; i < nvec; i++) {
+        auto kvec = kvecs.row(i);
+        auto normsq = kvec.dot(kvec);
+        BOOST_CHECK_LT(normsq, cutoffsq);
+        BOOST_CHECK_CLOSE(normsq, kvals(i) * kvals(i), 1e-13);
+      }  // for each k-vector
+    }    // for each cell
+  }      // end test case
+
+  /* ---------------------------------------------------------------------- */
+  /**
+   * @brief Check that the number of obtained k-vectors is consistent with
+   * the total number of searched vectors as well as the rigorous bound in
+   * https://arxiv.org/pdf/math/0410522.pdf in section 3.2.
+   */
+  BOOST_FIXTURE_TEST_CASE(kvecgen_numvectors_reasonable_test,
+                          KvecgenRefFixture) {
+    // For each cell: get the required quantities for the tests
+    const double cutoff = 6.28;
+    for (auto & cell : this->cells) {
+      // Get number of obtained k-vectors
+      math::Kvectors kvectors(cutoff, cell);
+      auto numvectors = kvectors.get_numvectors();
+
+      // Preparation: Calculate various mathematical quantities needed
+      // to generate the bounds. We start by recomputing the same auxilary
+      // quantities as in the main file. Please check out the main file
+      // src/rascal/math/kvec_generator.cc for more details.
+      const auto basis_vecs = 2.0 * math::PI * cell.transpose().inverse();
+      const auto M = basis_vecs * basis_vecs.transpose();
+      auto detM = M.determinant();
+      const auto n1max =
+          floor(sqrt((M(1, 1) * M(2, 2) - M(1, 2) * M(1, 2)) / detM) * cutoff);
+      const auto n2max =
+          floor(sqrt((M(0, 0) * M(2, 2) - M(0, 2) * M(0, 2)) / detM) * cutoff);
+      const auto n3max =
+          floor(sqrt((M(0, 0) * M(1, 1) - M(0, 1) * M(0, 1)) / detM) * cutoff);
+      const auto numvectors_searchbox =
+          n3max + n2max * (2 * n3max + 1) +
+          n1max * (2 * n2max + 1) * (2 * n3max + 1);
+
+      // Compute the estimated number of k-vectors based on the
+      // continuous approximation: the volume of the ball divided
+      // by the volume of a unit cell. In practice, we divide by
+      // a factor of 2 since we only return half of the vectors.
+      const auto numvectors_estimate =
+          2. * math::PI / 3. * math::pow(cutoff, 3) / sqrt(detM);
+
+      // Compute a factor used for the bounds on the deviation between
+      // the estimated computed above and the actual number of k-vectors.
+      Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> eig_solver;
+      const auto eigenvalues = eig_solver.compute(M).eigenvalues();
+      const auto bound_factor =
+          math::SQRT_THREE / 2. / cbrt(eigenvalues.maxCoeff());
+
+      // RUN ACTUAL TESTS:
+      // Number of found vectors has to be less than number in search box
+      BOOST_CHECK_LT(numvectors, numvectors_searchbox);
+
+      // Start generating upper and lower bounds from the paper
+      // mentioned above.
+      auto upperbound = math::pow((1. + bound_factor), 3) * numvectors_estimate;
+      auto lowerbound = math::pow((1. - bound_factor), 3) * numvectors_estimate;
+      BOOST_CHECK_LE(static_cast<double>(numvectors), upperbound);
+      BOOST_CHECK_GE(static_cast<double>(numvectors), lowerbound);
+    }  // for each cell
+  }    // end test case
+
+  /* ---------------------------------------------------------------------- */
+  /**
+   * @brief Test correct behavior under scaling
+   *
+   * If we double the cutoff as well as the basis vectors, the new
+   * vectors should be the doubled versions of the original vectors.
+   */
+  BOOST_FIXTURE_TEST_CASE(kvecgen_scaling_test, KvecgenRefFixture) {
+    // Get the required quantities for the tests
+    double cutoff = math::PI * 2;
+    double normsq;
+    for (auto & cell : this->cells) {
+      math::Kvectors kvectors(cutoff, cell, false);
+      int nvec = kvectors.get_numvectors();
+      Eigen::MatrixXd kvecs = kvectors.get_kvectors();
+      Eigen::VectorXd kvals = kvectors.get_kvector_norms();
+
+      // For multiple scaling factors, compare the k-vectors obtained
+      // before and after scaling. We are only using powers of two to
+      // eliminate unwanted behavior due to rounding errors.
+      double scales[2] = {0.5, 2};
+      for (auto & scale : scales) {
+        math::Kvectors kvectors_scaled(cutoff * scale, cell / scale);
+        int nvec_scaled = kvectors_scaled.get_numvectors();
+        Eigen::MatrixXd kvecs_scaled = kvectors_scaled.get_kvectors() / scale;
+        BOOST_CHECK_EQUAL(nvec, nvec_scaled);
+
+        // Check that the obtained vectors agree using squared norm
+        if (nvec == nvec_scaled) {
+          for (int ik = 0; ik < nvec; ik++) {
+            normsq = (kvecs.row(ik) - kvecs_scaled.row(ik)).squaredNorm();
+            BOOST_CHECK_LT(normsq, cutoff * cutoff * 1e-14);
+          }  // for all k-vectors (of this cell)
+        }    // if number of vectors agree
+      }      // for all scale factors
+    }        // for each cell
+  }          // end test case
+
+  /* ---------------------------------------------------------------------- */
+  /**
+   * @brief Test correct behavior under rotations
+   *
+   * If we rotate a (real space) cell and compute its k-vectors, the
+   * obtained k-vectors should be the same as the rotation applied to
+   * the k-vectors of the original cell (stored in the same order)
+   * The rotation matrices are generated randomly to avoid systematic
+   * biases.
+   */
+  BOOST_AUTO_TEST_CASE(kvecgen_rotation_test) {
+    // To make sure that rounding errors do not accidentally lead
+    // to unwanted errors, use a cutoff and cells that are quaranteed
+    // to be stable from Legendre's three squares theorem:
+    // For an integer (reciprocal) lattice or a sublattice thereof,
+    // the squared norm of k is an integer that is a sum of three
+    // squares. The numbers in the sequence https://oeis.org/A004215
+    // including the number 87 cannot be written as the sum of three
+    // squares, thus ensuring that there are no k-vectors whose squared
+    // norm satisfies 86 < k^2 < 88. This eliminates potential numerical
+    // problems from vectors lying exactly on the boundary.
+    // Note that the parameters are still chosen in a way that closely
+    // represent typical cells and cutoffs in applications.
+    double cutoff = sqrt(87);
+    std::vector<Eigen::Matrix3d> cells{};
+    Eigen::Matrix3d cell0;
+    // Cubic cell
+    cell0 << 1., 0., 0., 0., 1., 0., 0., 0., 1.;
+    cells.push_back(cell0);
+    // Tetragonal cell
+    cell0 << 2., 0., 0., 0., 1., 0., 0., 0., 1.;
+    cells.push_back(cell0);
+    // Orthorhombic cell
+    cell0 << 2., 0., 0., 0., 1., 0., 0., 0., 3.;
+    cells.push_back(cell0);
+
+    // Generate rotation matrices with fixed seed
+    srand(4653056);
+    size_t num_random = 100;
+    std::vector<Eigen::Matrix3d> rotation_matrices{};
+    for (size_t index = 0; index < num_random; index++) {
+      auto random_matrix = Eigen::Matrix3d::Random();
+      Eigen::Matrix3d rotation_matrix_0 =
+          random_matrix.householderQr().householderQ();
+      rotation_matrices.push_back(rotation_matrix_0);
+    }
+
+    // Identity to make sure the rotation matrices are orthogonal
+    auto identity_3 = Eigen::MatrixXd::Identity(3, 3);
+
+    for (auto & cell : cells) {
+      math::Kvectors kvectors_obj(cutoff, cell, true);
+      auto numvectors = kvectors_obj.get_numvectors();
+      auto kvectors = kvectors_obj.get_kvectors();
+      double total_squared_norm = kvectors.squaredNorm();
+
+      // Start rotations
+      for (auto & rotation : rotation_matrices) {
+        // Make sure that the rotation matrix is orthogonal
+        auto check_orthogonality = rotation * rotation.transpose();
+        auto delta_orthogonality = identity_3 - check_orthogonality;
+        BOOST_CHECK_LE(delta_orthogonality.array().abs().maxCoeff(), 1e-14);
+
+        // Generate k-vectors of rotated frame
+        math::Kvectors kvectors_rotated_obj(cutoff, cell * rotation, true);
+        auto numvectors_rotated = kvectors_rotated_obj.get_numvectors();
+        BOOST_CHECK_EQUAL(numvectors, numvectors_rotated);
+
+        // Compare obtained vectors
+        if (numvectors == numvectors_rotated) {
+          auto kvectors_rotated = kvectors_rotated_obj.get_kvectors();
+          kvectors_rotated = kvectors_rotated * rotation.transpose();
+          auto diff_kvectors = kvectors - kvectors_rotated;
+          // 2-norm
+          BOOST_CHECK_LE(diff_kvectors.squaredNorm(),
+                         total_squared_norm * 1e-15);
+          // infinity-norm
+          BOOST_CHECK_LE(diff_kvectors.array().abs().maxCoeff(), 1e-13);
+        }  // if numvectors agree
+      }    // for each rotation matrix
+    }      // for each cell
+  }        // end test case
+
+  /* ---------------------------------------------------------------------- */
+  BOOST_AUTO_TEST_SUITE_END();
+
+}  // namespace rascal


### PR DESCRIPTION
Implemented class for generating the k-vectors (reciprocal space vectors) used for the k-space implementation of LODE and more general spherical expansion coefficients.
The details and derivations of the algorithm used to generate the vectors is described in a supplementary document that can be provided if desired. 

Tests are provided to check that the code behaves reasonably under realistic conditions as well as some more artificial tests to catch boundary cases.

