### PR TITLE
Newlines are not allowed in Python package description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ with open("./requirements_pip.txt", "r") as fp:
 setup(
     name="rascal",
     version=version,
-    description="""A versatile and scalable computation of representations of
-atomic structures for machine learning.""",
+    description="""A versatile and scalable computation of representations of \
+    atomic structures for machine learning.""",
     author="librascal developers",
     license="LGPL-3.0-or-later",
     cmake_args=[


### PR DESCRIPTION
This fixes `pip install .` with the latest version of pip (issue discovered by @bananenpampe!). Without the change, pip fails the build with 

```
Processing /Users/guillaume/code/librascal
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  ERROR: Command errored out with exit status 1:
   command: /opt/miniconda3/bin/python /opt/miniconda3/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py get_requires_for_build_wheel /var/folders/v6/c9ym3wnn4c3c2t3r9sv4v02h0000gn/T/tmph2nyklro
       cwd: /Users/guillaume/code/librascal
  Complete output (38 lines):
  running egg_info
  writing bindings/rascal.egg-info/PKG-INFO
  Traceback (most recent call last):
    File "/opt/miniconda3/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
      main()
    File "/opt/miniconda3/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
    File "/opt/miniconda3/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 130, in get_requires_for_build_wheel
      return hook(config_settings)
    File "/private/var/folders/v6/c9ym3wnn4c3c2t3r9sv4v02h0000gn/T/pip-build-env-tzp2ef7d/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 162, in get_requires_for_build_wheel
      return self._get_build_requires(
    File "/private/var/folders/v6/c9ym3wnn4c3c2t3r9sv4v02h0000gn/T/pip-build-env-tzp2ef7d/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 143, in _get_build_requires
      self.run_setup()
    File "/private/var/folders/v6/c9ym3wnn4c3c2t3r9sv4v02h0000gn/T/pip-build-env-tzp2ef7d/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 158, in run_setup
      exec(compile(code, __file__, 'exec'), locals())
    File "setup.py", line 24, in <module>
      setup(
    File "/private/var/folders/v6/c9ym3wnn4c3c2t3r9sv4v02h0000gn/T/pip-build-env-tzp2ef7d/overlay/lib/python3.9/site-packages/skbuild/setuptools_wrap.py", line 469, in setup
      return upstream_setup(*args, **kw)
    File "/private/var/folders/v6/c9ym3wnn4c3c2t3r9sv4v02h0000gn/T/pip-build-env-tzp2ef7d/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 153, in setup
      return distutils.core.setup(**attrs)
    File "/opt/miniconda3/lib/python3.9/distutils/core.py", line 148, in setup
      dist.run_commands()
    File "/opt/miniconda3/lib/python3.9/distutils/dist.py", line 966, in run_commands
      self.run_command(cmd)
    File "/opt/miniconda3/lib/python3.9/distutils/dist.py", line 985, in run_command
      cmd_obj.run()
    File "/private/var/folders/v6/c9ym3wnn4c3c2t3r9sv4v02h0000gn/T/pip-build-env-tzp2ef7d/overlay/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 292, in run
      writer(self, ep.name, os.path.join(self.egg_info, ep.name))
    File "/private/var/folders/v6/c9ym3wnn4c3c2t3r9sv4v02h0000gn/T/pip-build-env-tzp2ef7d/overlay/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 656, in write_pkg_info
      metadata.write_pkg_info(cmd.egg_info)
    File "/opt/miniconda3/lib/python3.9/distutils/dist.py", line 1117, in write_pkg_info
      self.write_pkg_file(pkg_info)
    File "/private/var/folders/v6/c9ym3wnn4c3c2t3r9sv4v02h0000gn/T/pip-build-env-tzp2ef7d/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 167, in write_pkg_file
      write_field('Summary', single_line(self.get_description()))
    File "/private/var/folders/v6/c9ym3wnn4c3c2t3r9sv4v02h0000gn/T/pip-build-env-tzp2ef7d/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 151, in single_line
      raise ValueError('Newlines are not allowed')
  ValueError: Newlines are not allowed
```